### PR TITLE
Add Composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,6 @@ This library is in active development. If you have any feedback or suggestions, 
 
 Goals for future releases include:
 - [ ] [Support `const` keyword](https://json-schema.org/understanding-json-schema/reference/const#constant-values)
-- [ ] [Support schema composition (`allOf`, `anyOf`, `oneOf`, `not`)](https://json-schema.org/understanding-json-schema/reference/combining#allof)
 - [ ] [Support applying subschemas conditionally](https://json-schema.org/understanding-json-schema/reference/conditionals)
 - [ ] Support `$ref` and `$defs` keywords
 - [ ] Support enums in result builders and macro expansion

--- a/Sources/JSONSchema/Documentation.docc/Documentation.md
+++ b/Sources/JSONSchema/Documentation.docc/Documentation.md
@@ -8,7 +8,7 @@ Generate JSON Schema documents from Swift.
 
 At the core of the library is the ``Schema`` type, which is used to define the structure of a JSON schema document. The ``RootSchema`` type represents the root of the schema document, and the ``Schema`` type represents a JSON schema object.
 
-The ``Schema`` type provides a variety of factory methods to create different types of JSON schema type. For example, the ``Schema/string(_:_:enumValues:)`` method creates a schema object that represents a string type, and the ``Schema/object(_:_:enumValues:)`` method creates a schema object that represents an object type.
+The ``Schema`` type provides a variety of factory methods to create different types of JSON schema type. For example, the ``Schema/string(_:_:enumValues:composition:)`` method creates a schema object that represents a string type, and the ``Schema/object(_:_:enumValues:composition:)`` method creates a schema object that represents an object type.
 
 ```swift
 let veggie = Schema
@@ -47,6 +47,8 @@ let schema = RootSchema(
   )
 )
 ```
+
+Composition of schemas is supported with ``CompositionOptions`` on ``Schema/composition``.
 
 #### Annotations
 

--- a/Sources/JSONSchema/Schema+Codable.swift
+++ b/Sources/JSONSchema/Schema+Codable.swift
@@ -34,6 +34,7 @@ extension Schema: Codable {
     self.enumValues = try container.decodeIfPresent([JSONValue].self, forKey: .enumValues)
     self.annotations = try AnnotationOptions(from: decoder)
     self.options = if let type { try AnySchemaOptions(from: decoder, typeHint: type) } else { nil }
+    self.composition = try? CompositionOptions(from: decoder)
   }
 
   public func encode(to encoder: any Encoder) throws {
@@ -42,5 +43,6 @@ extension Schema: Codable {
     try container.encodeIfPresent(enumValues, forKey: .enumValues)
     try annotations.encode(to: encoder)
     try options?.encode(to: encoder)
+    try composition?.encode(to: encoder)
   }
 }

--- a/Sources/JSONSchema/Schema.swift
+++ b/Sources/JSONSchema/Schema.swift
@@ -173,7 +173,13 @@ public struct Schema: Sendable {
     enumValues: [JSONValue]? = nil,
     composition: CompositionOptions? = nil
   ) -> Schema {
-    .init(type: .integer, options: nil, annotations: annotations, enumValues: enumValues, composition: composition)
+    .init(
+      type: .integer,
+      options: nil,
+      annotations: annotations,
+      enumValues: enumValues,
+      composition: composition
+    )
   }
 
   /// Creates a schema definition for a number type.
@@ -193,7 +199,8 @@ public struct Schema: Sendable {
       type: .number,
       options: options.eraseToAnySchemaOptions(),
       annotations: annotations,
-      enumValues: enumValues, composition: composition
+      enumValues: enumValues,
+      composition: composition
     )
   }
 
@@ -214,7 +221,8 @@ public struct Schema: Sendable {
       type: .object,
       options: options.eraseToAnySchemaOptions(),
       annotations: annotations,
-      enumValues: enumValues, composition: composition
+      enumValues: enumValues,
+      composition: composition
     )
   }
 
@@ -235,7 +243,8 @@ public struct Schema: Sendable {
       type: .array,
       options: options.eraseToAnySchemaOptions(),
       annotations: annotations,
-      enumValues: enumValues, composition: composition
+      enumValues: enumValues,
+      composition: composition
     )
   }
 
@@ -250,7 +259,13 @@ public struct Schema: Sendable {
     enumValues: [JSONValue]? = nil,
     composition: CompositionOptions? = nil
   ) -> Schema {
-    .init(type: .boolean, options: nil, annotations: annotations, enumValues: enumValues, composition: composition)
+    .init(
+      type: .boolean,
+      options: nil,
+      annotations: annotations,
+      enumValues: enumValues,
+      composition: composition
+    )
   }
 
   /// Creates a schema definition for a null type.
@@ -263,7 +278,15 @@ public struct Schema: Sendable {
     _ annotations: AnnotationOptions = .annotations(),
     enumValues: [JSONValue]? = nil,
     composition: CompositionOptions? = nil
-  ) -> Schema { .init(type: .null, options: nil, annotations: annotations, enumValues: enumValues, composition: composition) }
+  ) -> Schema {
+    .init(
+      type: .null,
+      options: nil,
+      annotations: annotations,
+      enumValues: enumValues,
+      composition: composition
+    )
+  }
 
   /// Creates a schema definition with no explicit type.
   /// This is a special case. No type is specified, but the schema is still valid.
@@ -284,5 +307,13 @@ public struct Schema: Sendable {
     _ options: (any SchemaOptions)? = nil,
     enumValues: [JSONValue]? = nil,
     composition: CompositionOptions? = nil
-  ) -> Schema { .init(type: nil, options: options?.eraseToAnySchemaOptions(), annotations: annotations, enumValues: enumValues, composition: composition) }
+  ) -> Schema {
+    .init(
+      type: nil,
+      options: options?.eraseToAnySchemaOptions(),
+      annotations: annotations,
+      enumValues: enumValues,
+      composition: composition
+    )
+  }
 }

--- a/Sources/JSONSchema/Schema.swift
+++ b/Sources/JSONSchema/Schema.swift
@@ -296,7 +296,6 @@ public struct Schema: Sendable {
   }
 
   /// Creates a schema definition with no explicit type.
-  /// This is a special case. No type is specified, but the schema is still valid.
   ///
   /// Example:
   /// ```json
@@ -307,6 +306,7 @@ public struct Schema: Sendable {
   ///
   /// - Parameters:
   ///   - annotations: Additional annotations for the schema.
+  ///   - options: Additional options for any type.
   ///   - enumValues: An array of possible values for the schema.
   ///   - composition: Composition options for the schema.
   /// - Returns: A schema definition with no explicit type.

--- a/Sources/JSONSchema/Schema.swift
+++ b/Sources/JSONSchema/Schema.swift
@@ -136,6 +136,10 @@ public struct Schema: Sendable {
   /// [JSON Schema Reference](https://json-schema.org/understanding-json-schema/reference/enum)
   public let enumValues: [JSONValue]?
 
+  /// Composition options for the schema.
+  /// [JSON Schema Reference](https://json-schema.org/understanding-json-schema/reference/combining)
+  public let composition: CompositionOptions?
+
   /// Creates a schema definition for a string type.
   ///
   /// - Parameters:
@@ -146,13 +150,15 @@ public struct Schema: Sendable {
   public static func string(
     _ annotations: AnnotationOptions = .annotations(),
     _ options: StringSchemaOptions = .options(),
-    enumValues: [JSONValue]? = nil
+    enumValues: [JSONValue]? = nil,
+    composition: CompositionOptions? = nil
   ) -> Schema {
     .init(
       type: .string,
       options: options.eraseToAnySchemaOptions(),
       annotations: annotations,
-      enumValues: enumValues
+      enumValues: enumValues,
+      composition: composition
     )
   }
 
@@ -164,9 +170,10 @@ public struct Schema: Sendable {
   /// - Returns: A schema definition for an integer type.
   public static func integer(
     _ annotations: AnnotationOptions = .annotations(),
-    enumValues: [JSONValue]? = nil
+    enumValues: [JSONValue]? = nil,
+    composition: CompositionOptions? = nil
   ) -> Schema {
-    .init(type: .integer, options: nil, annotations: annotations, enumValues: enumValues)
+    .init(type: .integer, options: nil, annotations: annotations, enumValues: enumValues, composition: composition)
   }
 
   /// Creates a schema definition for a number type.
@@ -179,13 +186,14 @@ public struct Schema: Sendable {
   public static func number(
     _ annotations: AnnotationOptions = .annotations(),
     _ options: NumberSchemaOptions = .options(),
-    enumValues: [JSONValue]? = nil
+    enumValues: [JSONValue]? = nil,
+    composition: CompositionOptions? = nil
   ) -> Schema {
     .init(
       type: .number,
       options: options.eraseToAnySchemaOptions(),
       annotations: annotations,
-      enumValues: enumValues
+      enumValues: enumValues, composition: composition
     )
   }
 
@@ -199,13 +207,14 @@ public struct Schema: Sendable {
   public static func object(
     _ annotations: AnnotationOptions = .annotations(),
     _ options: ObjectSchemaOptions = .options(),
-    enumValues: [JSONValue]? = nil
+    enumValues: [JSONValue]? = nil,
+    composition: CompositionOptions? = nil
   ) -> Schema {
     .init(
       type: .object,
       options: options.eraseToAnySchemaOptions(),
       annotations: annotations,
-      enumValues: enumValues
+      enumValues: enumValues, composition: composition
     )
   }
 
@@ -219,13 +228,14 @@ public struct Schema: Sendable {
   public static func array(
     _ annotations: AnnotationOptions = .annotations(),
     _ options: ArraySchemaOptions = .options(),
-    enumValues: [JSONValue]? = nil
+    enumValues: [JSONValue]? = nil,
+    composition: CompositionOptions? = nil
   ) -> Schema {
     .init(
       type: .array,
       options: options.eraseToAnySchemaOptions(),
       annotations: annotations,
-      enumValues: enumValues
+      enumValues: enumValues, composition: composition
     )
   }
 
@@ -237,9 +247,10 @@ public struct Schema: Sendable {
   /// - Returns: A schema definition for a boolean type.
   public static func boolean(
     _ annotations: AnnotationOptions = .annotations(),
-    enumValues: [JSONValue]? = nil
+    enumValues: [JSONValue]? = nil,
+    composition: CompositionOptions? = nil
   ) -> Schema {
-    .init(type: .boolean, options: nil, annotations: annotations, enumValues: enumValues)
+    .init(type: .boolean, options: nil, annotations: annotations, enumValues: enumValues, composition: composition)
   }
 
   /// Creates a schema definition for a null type.
@@ -250,8 +261,9 @@ public struct Schema: Sendable {
   /// - Returns: A schema definition for a null type.
   public static func null(
     _ annotations: AnnotationOptions = .annotations(),
-    enumValues: [JSONValue]? = nil
-  ) -> Schema { .init(type: .null, options: nil, annotations: annotations, enumValues: enumValues) }
+    enumValues: [JSONValue]? = nil,
+    composition: CompositionOptions? = nil
+  ) -> Schema { .init(type: .null, options: nil, annotations: annotations, enumValues: enumValues, composition: composition) }
 
   /// Creates a schema definition with no explicit type.
   /// This is a special case. No type is specified, but the schema is still valid.
@@ -269,6 +281,8 @@ public struct Schema: Sendable {
   /// - Returns: A schema definition with no explicit type.
   public static func noType(
     _ annotations: AnnotationOptions = .annotations(),
-    enumValues: [JSONValue]? = nil
-  ) -> Schema { .init(type: nil, options: nil, annotations: annotations, enumValues: enumValues) }
+    _ options: (any SchemaOptions)? = nil,
+    enumValues: [JSONValue]? = nil,
+    composition: CompositionOptions? = nil
+  ) -> Schema { .init(type: nil, options: options?.eraseToAnySchemaOptions(), annotations: annotations, enumValues: enumValues, composition: composition) }
 }

--- a/Sources/JSONSchema/Schema.swift
+++ b/Sources/JSONSchema/Schema.swift
@@ -146,6 +146,7 @@ public struct Schema: Sendable {
   ///   - annotations: Additional annotations for the schema.
   ///   - options: Additional options specific to the string type.
   ///   - enumValues: An array of possible values for the schema.
+  ///   - composition: Composition options for the schema.
   /// - Returns: A schema definition for a string type.
   public static func string(
     _ annotations: AnnotationOptions = .annotations(),
@@ -167,6 +168,7 @@ public struct Schema: Sendable {
   /// - Parameters:
   ///   - annotations: Additional annotations for the schema.
   ///   - enumValues: An array of possible values for the schema.
+  ///   - composition: Composition options for the schema.
   /// - Returns: A schema definition for an integer type.
   public static func integer(
     _ annotations: AnnotationOptions = .annotations(),
@@ -188,6 +190,7 @@ public struct Schema: Sendable {
   ///   - annotations: Additional annotations for the schema.
   ///   - options: Additional options specific to the number type.
   ///   - enumValues: An array of possible values for the schema.
+  ///   - composition: Composition options for the schema.
   /// - Returns: A schema definition for a number type.
   public static func number(
     _ annotations: AnnotationOptions = .annotations(),
@@ -210,6 +213,7 @@ public struct Schema: Sendable {
   ///   - annotations: Additional annotations for the schema.
   ///   - options: Additional options specific to the object type.
   ///   - enumValues: An array of possible values for the schema.
+  ///   - composition: Composition options for the schema.
   /// - Returns: A schema definition for an object type.
   public static func object(
     _ annotations: AnnotationOptions = .annotations(),
@@ -232,6 +236,7 @@ public struct Schema: Sendable {
   ///   - annotations: Additional annotations for the schema.
   ///   - options: Additional options specific to the array type.
   ///   - enumValues: An array of possible values for the schema.
+  ///   - composition: Composition options for the schema.
   /// - Returns: A schema definition for an array type.
   public static func array(
     _ annotations: AnnotationOptions = .annotations(),
@@ -253,6 +258,7 @@ public struct Schema: Sendable {
   /// - Parameters:
   ///   - annotations: Additional annotations for the schema.
   ///   - enumValues: An array of possible values for the schema.
+  ///   - composition: Composition options for the schema.
   /// - Returns: A schema definition for a boolean type.
   public static func boolean(
     _ annotations: AnnotationOptions = .annotations(),
@@ -273,6 +279,7 @@ public struct Schema: Sendable {
   /// - Parameters:
   ///   - annotations: Additional annotations for the schema.
   ///   - enumValues: An array of possible values for the schema.
+  ///   - composition: Composition options for the schema.
   /// - Returns: A schema definition for a null type.
   public static func null(
     _ annotations: AnnotationOptions = .annotations(),
@@ -301,6 +308,7 @@ public struct Schema: Sendable {
   /// - Parameters:
   ///   - annotations: Additional annotations for the schema.
   ///   - enumValues: An array of possible values for the schema.
+  ///   - composition: Composition options for the schema.
   /// - Returns: A schema definition with no explicit type.
   public static func noType(
     _ annotations: AnnotationOptions = .annotations(),

--- a/Sources/JSONSchema/SchemaOptions/CompositionOptions.swift
+++ b/Sources/JSONSchema/SchemaOptions/CompositionOptions.swift
@@ -1,8 +1,7 @@
 /// Configure composition of JSON schemas. Keywords correspond to boolean algebra concepts AND, OR, XOR, and NOT.
 ///
 /// [JSON Schema Reference](https://json-schema.org/understanding-json-schema/reference/combining)
-public indirect enum CompositionOptions: Equatable, Sendable {
-  /// To validate against `allOf`, the given data must be valid against all of the given subschemas.
+public indirect enum CompositionOptions: Equatable, Sendable { /// To validate against `allOf`, the given data must be valid against all of the given subschemas.
   /// [JSON Schema Reference](https://json-schema.org/understanding-json-schema/reference/combining#allOf)
   case allOf([Schema])
 
@@ -39,7 +38,11 @@ extension CompositionOptions: Codable {
     } else if let not = try container.decodeIfPresent(Schema.self, forKey: .not) {
       self = .not(not)
     } else {
-      throw DecodingError.dataCorruptedError(forKey: CodingKeys.allOf, in: container, debugDescription: "Invalid CompositionOptions")
+      throw DecodingError.dataCorruptedError(
+        forKey: CodingKeys.allOf,
+        in: container,
+        debugDescription: "Invalid CompositionOptions"
+      )
     }
   }
 
@@ -47,14 +50,10 @@ extension CompositionOptions: Codable {
     var container = encoder.container(keyedBy: CodingKeys.self)
 
     switch self {
-    case .allOf(let schemas):
-      try container.encode(schemas, forKey: .allOf)
-    case .anyOf(let schemas):
-      try container.encode(schemas, forKey: .anyOf)
-    case .oneOf(let schemas):
-      try container.encode(schemas, forKey: .oneOf)
-    case .not(let schema):
-      try container.encode(schema, forKey: .not)
+    case .allOf(let schemas): try container.encode(schemas, forKey: .allOf)
+    case .anyOf(let schemas): try container.encode(schemas, forKey: .anyOf)
+    case .oneOf(let schemas): try container.encode(schemas, forKey: .oneOf)
+    case .not(let schema): try container.encode(schema, forKey: .not)
     }
   }
 }

--- a/Sources/JSONSchema/SchemaOptions/CompositionOptions.swift
+++ b/Sources/JSONSchema/SchemaOptions/CompositionOptions.swift
@@ -1,0 +1,69 @@
+/// Configure composition of JSON schemas. Keywords correspond to boolean algebra concepts AND, OR, XOR, and NOT.
+///
+/// [JSON Schema Reference](https://json-schema.org/understanding-json-schema/reference/combining)
+public indirect enum CompositionOptions: Equatable, Sendable {
+  /// To validate against `allOf`, the given data must be valid against all of the given subschemas.
+  /// [JSON Schema Reference](https://json-schema.org/understanding-json-schema/reference/combining#allOf)
+  case allOf([Schema])
+
+  /// To validate against `anyOf`, the given data must be valid against any (one or more) of the given subschemas.
+  /// [JSON Schema Reference](https://json-schema.org/understanding-json-schema/reference/combining#anyOf)
+  case anyOf([Schema])
+
+  /// To validate against `oneOf`, the given data must be valid against exactly one of the given subschemas.
+  /// [JSON Schema Reference](https://json-schema.org/understanding-json-schema/reference/combining#oneOf)
+  case oneOf([Schema])
+
+  /// The `not` keyword declares that an instance validates if it doesn't validate against the given subschema.
+  /// [JSON Schema Reference](https://json-schema.org/understanding-json-schema/reference/combining#not)
+  case not(Schema)
+}
+
+extension CompositionOptions: Codable {
+  enum CodingKeys: String, CodingKey {
+    case allOf
+    case anyOf
+    case oneOf
+    case not
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+
+    if let allOf = try container.decodeIfPresent([Schema].self, forKey: .allOf) {
+      self = .allOf(allOf)
+    } else if let anyOf = try container.decodeIfPresent([Schema].self, forKey: .anyOf) {
+      self = .anyOf(anyOf)
+    } else if let oneOf = try container.decodeIfPresent([Schema].self, forKey: .oneOf) {
+      self = .oneOf(oneOf)
+    } else if let not = try container.decodeIfPresent(Schema.self, forKey: .not) {
+      self = .not(not)
+    } else {
+      throw DecodingError.dataCorruptedError(forKey: CodingKeys.allOf, in: container, debugDescription: "Invalid CompositionOptions")
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    switch self {
+    case .allOf(let schemas):
+      try container.encode(schemas, forKey: .allOf)
+    case .anyOf(let schemas):
+      try container.encode(schemas, forKey: .anyOf)
+    case .oneOf(let schemas):
+      try container.encode(schemas, forKey: .oneOf)
+    case .not(let schema):
+      try container.encode(schema, forKey: .not)
+    }
+  }
+}
+
+//extension Schema: ExpressibleByArrayLiteral {
+//  public init(arrayLiteral elements: Schema...) {
+//    self = .array(
+//      .annotations(),
+//      .options(items: .schema(<#T##Schema#>))
+//    )
+//  }
+//}

--- a/Sources/JSONSchemaBuilder/Schema/JSONComposition.swift
+++ b/Sources/JSONSchemaBuilder/Schema/JSONComposition.swift
@@ -1,0 +1,43 @@
+import JSONSchema
+
+public enum JSONComposition {
+  public struct AnyOf: JSONSchemaComponent {
+    public var annotations: AnnotationOptions = .annotations()
+
+    public var definition: Schema
+
+    public init(@JSONSchemaBuilder _ builder: () -> [JSONSchemaComponent]) {
+      definition = .noType(composition: .anyOf(builder().map(\.definition)))
+    }
+  }
+
+  public struct AllOf: JSONSchemaComponent {
+    public var annotations: AnnotationOptions = .annotations()
+
+    public var definition: Schema
+
+    public init(@JSONSchemaBuilder _ builder: () -> [JSONSchemaComponent]) {
+      definition = .noType(composition: .allOf(builder().map(\.definition)))
+    }
+  }
+
+  public struct OneOf: JSONSchemaComponent {
+    public var annotations: AnnotationOptions = .annotations()
+
+    public var definition: Schema
+
+    public init(@JSONSchemaBuilder _ builder: () -> [JSONSchemaComponent]) {
+      definition = .noType(composition: .oneOf(builder().map(\.definition)))
+    }
+  }
+
+  public struct Not: JSONSchemaComponent {
+    public var annotations: AnnotationOptions = .annotations()
+
+    public var definition: Schema
+
+    public init(@JSONSchemaBuilder _ builder: () -> JSONSchemaComponent) {
+      definition = .noType(composition: .not(builder().definition))
+    }
+  }
+}

--- a/Sources/JSONSchemaClient/main.swift
+++ b/Sources/JSONSchemaClient/main.swift
@@ -82,8 +82,7 @@ printSchema(Library.self)
 // MARK: - Enums
 
 //@Schemable
-enum WeatherCondition: Codable {
-  case sunny(hoursOfSunlight: Int)
+enum WeatherCondition: Codable { case sunny(hoursOfSunlight: Int)
   case cloudy(coverage: Double)
   case rainy(chanceOfRain: Double, amount: Double)
   case snowy
@@ -105,17 +104,13 @@ extension WeatherCondition: Schemable {
     JSONComposition.AnyOf {
       JSONObject {
         JSONProperty(key: "sunny") {
-          JSONObject {
-            JSONProperty(key: "hoursOfSunlight", value: JSONInteger())
-          }
+          JSONObject { JSONProperty(key: "hoursOfSunlight", value: JSONInteger()) }
         }
       }
 
       JSONObject {
         JSONProperty(key: "cloudy") {
-          JSONObject {
-            JSONProperty(key: "coverage", value: JSONNumber())
-          }
+          JSONObject { JSONProperty(key: "coverage", value: JSONNumber()) }
         }
       }
 
@@ -128,11 +123,11 @@ extension WeatherCondition: Schemable {
         }
       }
 
-//        JSONEnum {
-//          "snowy"
-//          "windy"
-//          "stormy"
-//        }
+      //        JSONEnum {
+      //          "snowy"
+      //          "windy"
+      //          "stormy"
+      //        }
     }
   }
 }

--- a/Sources/JSONSchemaClient/main.swift
+++ b/Sources/JSONSchemaClient/main.swift
@@ -53,12 +53,6 @@ func printSchema<T: Schemable>(_ schema: T.Type) {
     String
 }
 
-//@Schemable
-//enum TemperatureType {
-//  case farhenheit
-//  case celcius
-//}
-
 let now = Weather(
   temperature: 72,
   humidity: 30,
@@ -84,3 +78,84 @@ printSchema(Weather.self)
 
 printSchema(Book.self)
 printSchema(Library.self)
+
+// MARK: - Enums
+
+//@Schemable
+enum WeatherCondition: Codable {
+  case sunny(hoursOfSunlight: Int)
+  case cloudy(coverage: Double)
+  case rainy(chanceOfRain: Double, amount: Double)
+  case snowy
+  case windy
+  case stormy
+}
+
+//extension TemperatureType: Schemable {
+//  static var schema: JSONSchemaComponent {
+//    JSONEnum {
+//      "fahrenheit"
+//      "celcius"
+//    }
+//  }
+//}
+
+extension WeatherCondition: Schemable {
+  static var schema: JSONSchemaComponent {
+    JSONComposition.AnyOf {
+      JSONObject {
+        JSONProperty(key: "sunny") {
+          JSONObject {
+            JSONProperty(key: "hoursOfSunlight", value: JSONInteger())
+          }
+        }
+      }
+
+      JSONObject {
+        JSONProperty(key: "cloudy") {
+          JSONObject {
+            JSONProperty(key: "coverage", value: JSONNumber())
+          }
+        }
+      }
+
+      JSONObject {
+        JSONProperty(key: "rainy") {
+          JSONObject {
+            JSONProperty(key: "chanceOfRain", value: JSONNumber())
+            JSONProperty(key: "amount", value: JSONNumber())
+          }
+        }
+      }
+
+//        JSONEnum {
+//          "snowy"
+//          "windy"
+//          "stormy"
+//        }
+    }
+  }
+}
+
+//@Schemable
+enum TemperatureType: Codable {
+  case fahrenheit
+  case celcius
+}
+
+//@Schemable
+//struct NewWeather {
+//  let temperature: Double
+//  let unit: TemperatureType
+//}
+//
+//let temperatureType = TemperatureType.celcius
+//printInstance(temperatureType)
+//
+//let temperatureString = #"{"celcius": {}}"#
+//let decoder = JSONDecoder()
+//try! decoder.decode(TemperatureType.self, from: temperatureString.data(using: .utf8)!)
+//
+let conditions = WeatherCondition.sunny(hoursOfSunlight: 5)
+printInstance(conditions)
+printSchema(WeatherCondition.self)

--- a/Tests/JSONSchemaBuilderTests/JSONCompositionTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONCompositionTests.swift
@@ -1,0 +1,76 @@
+import JSONSchema
+import Testing
+
+@testable import JSONSchemaBuilder
+
+struct JSONCompositionTests {
+  @Test func anyOfComposition() throws {
+    @JSONSchemaBuilder var sample: JSONSchemaComponent {
+      JSONComposition.AnyOf {
+        JSONString()
+        JSONNumber().minimum(0)
+      }
+    }
+
+    let expectedSchema = Schema.noType(
+      composition: .anyOf([
+        .string(),
+        .number(.annotations(), .options(minimum: 0))
+      ])
+    )
+
+    #expect(sample.definition == expectedSchema)
+  }
+
+  @Test func allOfComposition() throws {
+    @JSONSchemaBuilder var sample: JSONSchemaComponent {
+      JSONComposition.AllOf {
+        JSONString()
+        JSONNumber().maximum(10)
+      }
+    }
+
+    let expectedSchema = Schema.noType(
+      composition: .allOf([
+        .string(),
+        .number(.annotations(), .options(maximum: 10))
+      ])
+    )
+
+    #expect(sample.definition == expectedSchema)
+  }
+
+  @Test func oneOfComposition() throws {
+    @JSONSchemaBuilder var sample: JSONSchemaComponent {
+      JSONComposition.OneOf {
+        JSONString().pattern("^[a-zA-Z]+$")
+        JSONBoolean()
+      }
+    }
+
+    let expectedSchema = Schema.noType(
+      composition: .oneOf([
+        .string(.annotations(), .options(pattern: "^[a-zA-Z]+$")),
+        .boolean()
+      ])
+    )
+
+    #expect(sample.definition == expectedSchema)
+  }
+
+  @Test func notComposition() throws {
+    @JSONSchemaBuilder var sample: JSONSchemaComponent {
+      JSONComposition.Not {
+        JSONString()
+      }
+    }
+
+    let expectedSchema = Schema.noType(
+      composition: .not(
+        .string()
+      )
+    )
+
+    #expect(sample.definition == expectedSchema)
+  }
+}

--- a/Tests/JSONSchemaBuilderTests/JSONCompositionTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONCompositionTests.swift
@@ -13,10 +13,7 @@ struct JSONCompositionTests {
     }
 
     let expectedSchema = Schema.noType(
-      composition: .anyOf([
-        .string(),
-        .number(.annotations(), .options(minimum: 0))
-      ])
+      composition: .anyOf([.string(), .number(.annotations(), .options(minimum: 0))])
     )
 
     #expect(sample.definition == expectedSchema)
@@ -31,10 +28,7 @@ struct JSONCompositionTests {
     }
 
     let expectedSchema = Schema.noType(
-      composition: .allOf([
-        .string(),
-        .number(.annotations(), .options(maximum: 10))
-      ])
+      composition: .allOf([.string(), .number(.annotations(), .options(maximum: 10))])
     )
 
     #expect(sample.definition == expectedSchema)
@@ -49,27 +43,16 @@ struct JSONCompositionTests {
     }
 
     let expectedSchema = Schema.noType(
-      composition: .oneOf([
-        .string(.annotations(), .options(pattern: "^[a-zA-Z]+$")),
-        .boolean()
-      ])
+      composition: .oneOf([.string(.annotations(), .options(pattern: "^[a-zA-Z]+$")), .boolean()])
     )
 
     #expect(sample.definition == expectedSchema)
   }
 
   @Test func notComposition() throws {
-    @JSONSchemaBuilder var sample: JSONSchemaComponent {
-      JSONComposition.Not {
-        JSONString()
-      }
-    }
+    @JSONSchemaBuilder var sample: JSONSchemaComponent { JSONComposition.Not { JSONString() } }
 
-    let expectedSchema = Schema.noType(
-      composition: .not(
-        .string()
-      )
-    )
+    let expectedSchema = Schema.noType(composition: .not(.string()))
 
     #expect(sample.definition == expectedSchema)
   }

--- a/Tests/JSONSchemaTests/CompositionCodableSchemaTests.swift
+++ b/Tests/JSONSchemaTests/CompositionCodableSchemaTests.swift
@@ -6,12 +6,9 @@ import Testing
 struct CompositionCodableSchemaTests {
   @Test func allOf() throws {
     let schema = Schema.noType(
-      composition: .allOf(
-        [
-          .string(),
-          .noType(.annotations(), StringSchemaOptions.options(maxLength: 5)),
-        ]
-      )
+      composition: .allOf([
+        .string(), .noType(.annotations(), StringSchemaOptions.options(maxLength: 5)),
+      ])
     )
     let jsonString = """
       {
@@ -26,18 +23,16 @@ struct CompositionCodableSchemaTests {
       }
       """
     let json = try schema.json()
-    #expect(json == jsonString) // Encoding
-    #expect(try Schema(json: jsonString) == schema) // Decoding
+    #expect(json == jsonString)  // Encoding
+    #expect(try Schema(json: jsonString) == schema)  // Decoding
   }
 
   @Test func anyOf() throws {
     let schema = Schema.noType(
-      composition: .anyOf(
-        [
-          .string(.annotations(), .options(maxLength: 5)),
-          .number(.annotations(), .options(minimum: 0)),
-        ]
-      )
+      composition: .anyOf([
+        .string(.annotations(), .options(maxLength: 5)),
+        .number(.annotations(), .options(minimum: 0)),
+      ])
     )
     let jsonString = """
       {
@@ -54,18 +49,16 @@ struct CompositionCodableSchemaTests {
       }
       """
     let json = try schema.json()
-    #expect(json == jsonString) // Encoding
-    #expect(try Schema(json: jsonString) == schema) // Decoding
+    #expect(json == jsonString)  // Encoding
+    #expect(try Schema(json: jsonString) == schema)  // Decoding
   }
 
   @Test func oneOf() throws {
     let schema = Schema.noType(
-      composition: .oneOf(
-        [
-          .number(.annotations(), .options(multipleOf: 5)),
-          .number(.annotations(), .options(multipleOf: 3)),
-        ]
-      )
+      composition: .oneOf([
+        .number(.annotations(), .options(multipleOf: 5)),
+        .number(.annotations(), .options(multipleOf: 3)),
+      ])
     )
     let jsonString = """
       {
@@ -82,18 +75,16 @@ struct CompositionCodableSchemaTests {
       }
       """
     let json = try schema.json()
-    #expect(json == jsonString) // Encoding
-    #expect(try Schema(json: jsonString) == schema) // Decoding
+    #expect(json == jsonString)  // Encoding
+    #expect(try Schema(json: jsonString) == schema)  // Decoding
   }
 
   @Test func factored() throws {
     let schema = Schema.number(
-      composition: .oneOf(
-        [
-          .noType(.annotations(), NumberSchemaOptions.options(multipleOf: 5)),
-          .noType(.annotations(), NumberSchemaOptions.options(multipleOf: 3)),
-        ]
-      )
+      composition: .oneOf([
+        .noType(.annotations(), NumberSchemaOptions.options(multipleOf: 5)),
+        .noType(.annotations(), NumberSchemaOptions.options(multipleOf: 3)),
+      ])
     )
     let jsonString = """
       {
@@ -109,16 +100,12 @@ struct CompositionCodableSchemaTests {
       }
       """
     let json = try schema.json()
-    #expect(json == jsonString) // Encoding
-    #expect(try Schema(json: jsonString) == schema) // Decoding
+    #expect(json == jsonString)  // Encoding
+    #expect(try Schema(json: jsonString) == schema)  // Decoding
   }
 
   @Test func not() throws {
-    let schema = Schema.noType(
-      composition: .not(
-        .string()
-      )
-    )
+    let schema = Schema.noType(composition: .not(.string()))
     let jsonString = """
       {
         "not" : {
@@ -127,7 +114,7 @@ struct CompositionCodableSchemaTests {
       }
       """
     let json = try schema.json()
-    #expect(json == jsonString) // Encoding
-    #expect(try Schema(json: jsonString) == schema) // Decoding
+    #expect(json == jsonString)  // Encoding
+    #expect(try Schema(json: jsonString) == schema)  // Decoding
   }
 }

--- a/Tests/JSONSchemaTests/CompositionCodableSchemaTests.swift
+++ b/Tests/JSONSchemaTests/CompositionCodableSchemaTests.swift
@@ -112,4 +112,22 @@ struct CompositionCodableSchemaTests {
     #expect(json == jsonString) // Encoding
     #expect(try Schema(json: jsonString) == schema) // Decoding
   }
+
+  @Test func not() throws {
+    let schema = Schema.noType(
+      composition: .not(
+        .string()
+      )
+    )
+    let jsonString = """
+      {
+        "not" : {
+          "type" : "string"
+        }
+      }
+      """
+    let json = try schema.json()
+    #expect(json == jsonString) // Encoding
+    #expect(try Schema(json: jsonString) == schema) // Decoding
+  }
 }

--- a/Tests/JSONSchemaTests/CompositionCodableSchemaTests.swift
+++ b/Tests/JSONSchemaTests/CompositionCodableSchemaTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+
+@testable import JSONSchema
+
+struct CompositionCodableSchemaTests {
+  @Test func allOf() throws {
+    let schema = Schema.noType(
+      composition: .allOf(
+        [
+          .string(),
+          .noType(.annotations(), StringSchemaOptions.options(maxLength: 5)),
+        ]
+      )
+    )
+    let jsonString = """
+      {
+        "allOf" : [
+          {
+            "type" : "string"
+          },
+          {
+            "maxLength" : 5
+          }
+        ]
+      }
+      """
+    let json = try schema.json()
+    #expect(json == jsonString) // Encoding
+    #expect(try Schema(json: jsonString) == schema) // Decoding
+  }
+
+  @Test func anyOf() throws {
+    let schema = Schema.noType(
+      composition: .anyOf(
+        [
+          .string(.annotations(), .options(maxLength: 5)),
+          .number(.annotations(), .options(minimum: 0)),
+        ]
+      )
+    )
+    let jsonString = """
+      {
+        "anyOf" : [
+          {
+            "maxLength" : 5,
+            "type" : "string"
+          },
+          {
+            "minimum" : 0,
+            "type" : "number"
+          }
+        ]
+      }
+      """
+    let json = try schema.json()
+    #expect(json == jsonString) // Encoding
+    #expect(try Schema(json: jsonString) == schema) // Decoding
+  }
+
+  @Test func oneOf() throws {
+    let schema = Schema.noType(
+      composition: .oneOf(
+        [
+          .number(.annotations(), .options(multipleOf: 5)),
+          .number(.annotations(), .options(multipleOf: 3)),
+        ]
+      )
+    )
+    let jsonString = """
+      {
+        "oneOf" : [
+          {
+            "multipleOf" : 5,
+            "type" : "number"
+          },
+          {
+            "multipleOf" : 3,
+            "type" : "number"
+          }
+        ]
+      }
+      """
+    let json = try schema.json()
+    #expect(json == jsonString) // Encoding
+    #expect(try Schema(json: jsonString) == schema) // Decoding
+  }
+
+  @Test func factored() throws {
+    let schema = Schema.number(
+      composition: .oneOf(
+        [
+          .noType(.annotations(), NumberSchemaOptions.options(multipleOf: 5)),
+          .noType(.annotations(), NumberSchemaOptions.options(multipleOf: 3)),
+        ]
+      )
+    )
+    let jsonString = """
+      {
+        "oneOf" : [
+          {
+            "multipleOf" : 5
+          },
+          {
+            "multipleOf" : 3
+          }
+        ],
+        "type" : "number"
+      }
+      """
+    let json = try schema.json()
+    #expect(json == jsonString) // Encoding
+    #expect(try Schema(json: jsonString) == schema) // Decoding
+  }
+}

--- a/Tests/JSONSchemaTests/SchemaEquatableTests.swift
+++ b/Tests/JSONSchemaTests/SchemaEquatableTests.swift
@@ -39,7 +39,13 @@ struct SchemaEquatableTests {
 
   @Test func inconguentOptions() {
     #expect(
-      Schema(type: .object, options: nil, annotations: .annotations(), enumValues: nil, composition: nil)
+      Schema(
+        type: .object,
+        options: nil,
+        annotations: .annotations(),
+        enumValues: nil,
+        composition: nil
+      )
         != Schema(
           type: .object,
           options: ObjectSchemaOptions().eraseToAnySchemaOptions(),

--- a/Tests/JSONSchemaTests/SchemaEquatableTests.swift
+++ b/Tests/JSONSchemaTests/SchemaEquatableTests.swift
@@ -39,12 +39,13 @@ struct SchemaEquatableTests {
 
   @Test func inconguentOptions() {
     #expect(
-      Schema(type: .object, options: nil, annotations: .annotations(), enumValues: nil)
+      Schema(type: .object, options: nil, annotations: .annotations(), enumValues: nil, composition: nil)
         != Schema(
           type: .object,
           options: ObjectSchemaOptions().eraseToAnySchemaOptions(),
           annotations: .annotations(),
-          enumValues: nil
+          enumValues: nil,
+          composition: nil
         )
     )
   }


### PR DESCRIPTION
## Description

Adds support for composition with `anyOf`, `allOf`, `oneOf`, and `not`

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.

---

**Note:** You can add the `auto-format` label to this pull request to enable automatic Swift formatting.
