### PR TITLE
Support const keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ Once added, you can import `JSONSchema` in your Swift files and start using it i
 This library is in active development. If you have any feedback or suggestions, please open an issue or pull request.
 
 Goals for future releases include:
-- [ ] [Support `const` keyword](https://json-schema.org/understanding-json-schema/reference/const#constant-values)
 - [ ] [Support applying subschemas conditionally](https://json-schema.org/understanding-json-schema/reference/conditionals)
 - [ ] Support `$ref` and `$defs` keywords
 - [ ] Support enums in result builders and macro expansion

--- a/Sources/JSONSchema/Schema+Codable.swift
+++ b/Sources/JSONSchema/Schema+Codable.swift
@@ -24,7 +24,7 @@ extension RootSchema: Codable {
 
 extension Schema: Codable {
   enum CodingKeys: String, CodingKey {
-    case type
+    case type, const
     case enumValues = "enum"
   }
 
@@ -35,6 +35,7 @@ extension Schema: Codable {
     self.annotations = try AnnotationOptions(from: decoder)
     self.options = if let type { try AnySchemaOptions(from: decoder, typeHint: type) } else { nil }
     self.composition = try? CompositionOptions(from: decoder)
+    self.const = try container.decodeIfPresent(JSONValue.self, forKey: .const)
   }
 
   public func encode(to encoder: any Encoder) throws {
@@ -44,5 +45,6 @@ extension Schema: Codable {
     try annotations.encode(to: encoder)
     try options?.encode(to: encoder)
     try composition?.encode(to: encoder)
+    try container.encodeIfPresent(const, forKey: .const)
   }
 }

--- a/Sources/JSONSchema/Schema.swift
+++ b/Sources/JSONSchema/Schema.swift
@@ -139,6 +139,10 @@ public struct Schema: Sendable {
   /// Composition options for the schema.
   /// [JSON Schema Reference](https://json-schema.org/understanding-json-schema/reference/combining)
   public let composition: CompositionOptions?
+  
+  /// A single value that the schema must match.
+  /// [JSON Schema Reference](https://json-schema.org/understanding-json-schema/reference/const#constant-values)
+  public let const: JSONValue?
 
   /// Creates a schema definition for a string type.
   ///
@@ -159,7 +163,8 @@ public struct Schema: Sendable {
       options: options.eraseToAnySchemaOptions(),
       annotations: annotations,
       enumValues: enumValues,
-      composition: composition
+      composition: composition,
+      const: nil
     )
   }
 
@@ -180,7 +185,8 @@ public struct Schema: Sendable {
       options: nil,
       annotations: annotations,
       enumValues: enumValues,
-      composition: composition
+      composition: composition,
+      const: nil
     )
   }
 
@@ -203,7 +209,8 @@ public struct Schema: Sendable {
       options: options.eraseToAnySchemaOptions(),
       annotations: annotations,
       enumValues: enumValues,
-      composition: composition
+      composition: composition,
+      const: nil
     )
   }
 
@@ -226,7 +233,8 @@ public struct Schema: Sendable {
       options: options.eraseToAnySchemaOptions(),
       annotations: annotations,
       enumValues: enumValues,
-      composition: composition
+      composition: composition,
+      const: nil
     )
   }
 
@@ -249,7 +257,8 @@ public struct Schema: Sendable {
       options: options.eraseToAnySchemaOptions(),
       annotations: annotations,
       enumValues: enumValues,
-      composition: composition
+      composition: composition,
+      const: nil
     )
   }
 
@@ -270,7 +279,8 @@ public struct Schema: Sendable {
       options: nil,
       annotations: annotations,
       enumValues: enumValues,
-      composition: composition
+      composition: composition,
+      const: nil
     )
   }
 
@@ -291,7 +301,8 @@ public struct Schema: Sendable {
       options: nil,
       annotations: annotations,
       enumValues: enumValues,
-      composition: composition
+      composition: composition,
+      const: nil
     )
   }
 
@@ -321,7 +332,20 @@ public struct Schema: Sendable {
       options: options?.eraseToAnySchemaOptions(),
       annotations: annotations,
       enumValues: enumValues,
-      composition: composition
+      composition: composition,
+      const: nil
     )
   }
+
+  /// Creates a schema definition that only accepts a single value.
+  ///
+  /// - Parameters:
+  ///   - annotations: Additional annotations for the schema.
+  ///   - value: The value that the schema must match.
+  ///   - type: The type of the value. This is optional and can be inferred from the value.
+  public static func const(
+    _ annotations: AnnotationOptions = .annotations(),
+    _ value: JSONValue,
+    type: JSONType? = nil
+  ) -> Schema { .init(type: type, options: nil, annotations: annotations, enumValues: nil, composition: nil,  const: value) }
 }

--- a/Sources/JSONSchema/Schema.swift
+++ b/Sources/JSONSchema/Schema.swift
@@ -342,6 +342,7 @@ public struct Schema: Sendable {
   ///   - annotations: Additional annotations for the schema.
   ///   - value: The value that the schema must match.
   ///   - type: The type of the value. This is optional and can be inferred from the value.
+  /// - Returns: A schema definition that accepts only a constant.
   public static func const(
     _ annotations: AnnotationOptions = .annotations(),
     _ value: JSONValue,

--- a/Sources/JSONSchema/Schema.swift
+++ b/Sources/JSONSchema/Schema.swift
@@ -139,7 +139,6 @@ public struct Schema: Sendable {
   /// Composition options for the schema.
   /// [JSON Schema Reference](https://json-schema.org/understanding-json-schema/reference/combining)
   public let composition: CompositionOptions?
-  
   /// A single value that the schema must match.
   /// [JSON Schema Reference](https://json-schema.org/understanding-json-schema/reference/const#constant-values)
   public let const: JSONValue?
@@ -347,5 +346,14 @@ public struct Schema: Sendable {
     _ annotations: AnnotationOptions = .annotations(),
     _ value: JSONValue,
     type: JSONType? = nil
-  ) -> Schema { .init(type: type, options: nil, annotations: annotations, enumValues: nil, composition: nil,  const: value) }
+  ) -> Schema {
+    .init(
+      type: type,
+      options: nil,
+      annotations: annotations,
+      enumValues: nil,
+      composition: nil,
+      const: value
+    )
+  }
 }

--- a/Tests/JSONSchemaTests/DecodingSchemaTests.swift
+++ b/Tests/JSONSchemaTests/DecodingSchemaTests.swift
@@ -299,6 +299,28 @@ struct DecodingSchemaTests {
     #expect(schema.enumValues == ["Hello", 1, nil, 4.5])
   }
 
+  @Test func const() throws {
+    let json = """
+      {
+        "const" : "United States of America"
+      }
+      """
+    let schema = try Schema(json: json)
+    #expect(schema == Schema.const(.annotations(), "United States of America"))
+  }
+
+  @Test func constWithType() throws {
+    let json = """
+      {
+        "const" : "United States of America",
+        "type" : "string"
+      }
+      """
+    let schema = try Schema(json: json)
+    #expect(schema.const == "United States of America")
+    #expect(schema.type == .string)
+  }
+
   @Test func invalidValue() {
     let json = """
       {

--- a/Tests/JSONSchemaTests/EncodingSchemaTests.swift
+++ b/Tests/JSONSchemaTests/EncodingSchemaTests.swift
@@ -299,6 +299,29 @@ struct EncodingSchemaTests {
     )
   }
 
+  @Test func const() throws {
+    let schema = Schema.const(.annotations(), "United States of America")
+    let json = try schema.json()
+    #expect(json == """
+      {
+        "const" : "United States of America"
+      }
+      """
+    )
+  }
+
+  @Test func constWithType() throws {
+    let schema = Schema.const(.annotations(), "United States of America", type: .string)
+    let json = try schema.json()
+    #expect(json == """
+      {
+        "const" : "United States of America",
+        "type" : "string"
+      }
+      """
+    )
+  }
+
   @Test func root() throws {
     let schema = RootSchema(
       id: "https://example.com/schemas/myschema",

--- a/Tests/JSONSchemaTests/EncodingSchemaTests.swift
+++ b/Tests/JSONSchemaTests/EncodingSchemaTests.swift
@@ -302,23 +302,25 @@ struct EncodingSchemaTests {
   @Test func const() throws {
     let schema = Schema.const(.annotations(), "United States of America")
     let json = try schema.json()
-    #expect(json == """
-      {
-        "const" : "United States of America"
-      }
-      """
+    #expect(
+      json == """
+        {
+          "const" : "United States of America"
+        }
+        """
     )
   }
 
   @Test func constWithType() throws {
     let schema = Schema.const(.annotations(), "United States of America", type: .string)
     let json = try schema.json()
-    #expect(json == """
-      {
-        "const" : "United States of America",
-        "type" : "string"
-      }
-      """
+    #expect(
+      json == """
+        {
+          "const" : "United States of America",
+          "type" : "string"
+        }
+        """
     )
   }
 

--- a/Tests/JSONSchemaTests/SchemaEquatableTests.swift
+++ b/Tests/JSONSchemaTests/SchemaEquatableTests.swift
@@ -44,14 +44,16 @@ struct SchemaEquatableTests {
         options: nil,
         annotations: .annotations(),
         enumValues: nil,
-        composition: nil
+        composition: nil,
+        const: nil
       )
         != Schema(
           type: .object,
           options: ObjectSchemaOptions().eraseToAnySchemaOptions(),
           annotations: .annotations(),
           enumValues: nil,
-          composition: nil
+          composition: nil,
+          const: nil
         )
     )
   }


### PR DESCRIPTION
## Description

Adds support for the const keyword
https://json-schema.org/understanding-json-schema/reference/const#constant-values

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.

---

**Note:** You can add the `auto-format` label to this pull request to enable automatic Swift formatting.
