### PR TITLE
Add exclude from schema macro

### DIFF
--- a/Sources/JSONSchema/Documentation.docc/Documentation.md
+++ b/Sources/JSONSchema/Documentation.docc/Documentation.md
@@ -52,9 +52,9 @@ Composition of schemas is supported with ``CompositionOptions`` on ``Schema/comp
 
 #### Annotations
 
-``AnnotationsOptions`` can be added to a schema object using the ``AnnotationOptions/annotations(title:description:default:examples:readOnly:writeOnly:deprecated:comment:)`` factory method. This is the first argument in the ``Schema`` factory methods.
+``AnnotationOptions`` can be added to a schema object using the ``AnnotationOptions/annotations(title:description:default:examples:readOnly:writeOnly:deprecated:comment:)`` factory method. This is the first argument in the ``Schema`` factory methods.
 
-Annotations are used to provide additional information about the schema object. For example, the ``title`` annotation provides a title for the schema object, and the ``description`` annotation provides a description of the schema object. They are typically not used for validation.
+Annotations are used to provide additional information about the schema object. For example, the ``AnnotationOptions/title`` annotation provides a title for the schema object, and the ``AnnotationOptions/description`` annotation provides a description of the schema object. They are typically not used for validation.
 
 ```swift
 let schema = Schema

--- a/Sources/JSONSchemaBuilder/Documentation.docc/Documentation.md
+++ b/Sources/JSONSchemaBuilder/Documentation.docc/Documentation.md
@@ -417,3 +417,19 @@ struct Weather {
   }
 }
 ```
+
+#### Exclude from schema
+
+Use the ``ExcludeFromSchema()`` macro on a property you wish to exclude from the generated schema.
+
+```swift
+@Schemable
+struct Weather {
+  let temperature: Double
+  let units: TemperatureType
+  let location: String
+
+  @ExcludeFromSchema
+  let secret: String
+}
+```

--- a/Sources/JSONSchemaBuilder/Macros/SchemaOptions/ExcludeFromSchema.swift
+++ b/Sources/JSONSchemaBuilder/Macros/SchemaOptions/ExcludeFromSchema.swift
@@ -1,0 +1,2 @@
+@attached(peer) public macro ExcludeFromSchema() =
+  #externalMacro(module: "JSONSchemaMacro", type: "ExcludeFromSchemaMacro")

--- a/Sources/JSONSchemaClient/main.swift
+++ b/Sources/JSONSchemaClient/main.swift
@@ -69,7 +69,7 @@ printSchema(Weather.self)
   let title: String
   let authors: [String]
   let yearPublished: Int
-  let rating: Double
+  @ExcludeFromSchema let rating: Double
 }
 
 @Schemable struct Library {

--- a/Sources/JSONSchemaMacro/ExcludeFromSchemaMacro.swift
+++ b/Sources/JSONSchemaMacro/ExcludeFromSchemaMacro.swift
@@ -1,0 +1,10 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct ExcludeFromSchemaMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] { [] }
+}

--- a/Sources/JSONSchemaMacro/JSONSchemaMacroPlugin.swift
+++ b/Sources/JSONSchemaMacro/JSONSchemaMacroPlugin.swift
@@ -4,6 +4,6 @@ import SwiftSyntaxMacros
 @main struct JSONSchemaMacroPlugin: CompilerPlugin {
   let providingMacros: [Macro.Type] = [
     SchemableMacro.self, SchemaOptionsMacro.self, NumberOptionsMacro.self, ArrayOptionsMacro.self,
-    ObjectOptionsMacro.self, StringOptionsMacro.self,
+    ObjectOptionsMacro.self, StringOptionsMacro.self, ExcludeFromSchemaMacro.self,
   ]
 }

--- a/Sources/JSONSchemaMacro/Schemable/SwiftSyntaxExtensions.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SwiftSyntaxExtensions.swift
@@ -102,11 +102,21 @@ extension PatternBindingListSyntax.Element {
   }
 }
 
+extension VariableDeclSyntax {
+  var shouldExcludedFromSchema: Bool {
+    !attributes.compactMap {
+      $0.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.name.text
+    }
+    .contains(where: { $0 == "ExcludeFromSchema" })
+  }
+}
+
 extension MemberBlockItemListSyntax {
   func schemableMembers() -> [SchemableMember] {
     self.compactMap { $0.decl.as(VariableDeclSyntax.self) }
       .flatMap { variableDecl in variableDecl.bindings.map { (variableDecl, $0) } }
-      .filter { $0.1.isStoredProperty }.compactMap(SchemableMember.init)
+      .filter { $0.0.shouldExcludedFromSchema }.filter { $0.1.isStoredProperty }
+      .compactMap(SchemableMember.init)
   }
 
   func schemableEnumCases() -> [SchemableEnumCase] {


### PR DESCRIPTION
## Description

Adds a new macro that prevents member of struct or class from being included in schemable expansion.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.

---

**Note:** You can add the `auto-format` label to this pull request to enable automatic Swift formatting.
