### PR TITLE
Parse API improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ let data = """
 let weather: Parsed<Weather, ParseIssue> = Weather.schema.parse(instance: data)
 ```
 
-**Comming soon** Optionally combine parsing and validation in a single step.
+Optionally, combine parsing and validation in a single step.
 
 ```swift
 let weather: Weather = try Weather.schema.parseAndValidate(instance: data)

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ let data = """
   "conditions": "Sunny"
 }
 """
-let weather: Validated<Weather, String> = Weather.schema.parse(instance: data)
+let weather: Parsed<Weather, ParseIssue> = Weather.schema.parse(instance: data)
 ```
 
 **Comming soon** Optionally combine parsing and validation in a single step.

--- a/Sources/JSONSchemaBuilder/Builders/JSONPropertySchemaBuilder.swift
+++ b/Sources/JSONSchemaBuilder/Builders/JSONPropertySchemaBuilder.swift
@@ -32,14 +32,14 @@ public protocol PropertyCollection: Sendable {
 
   var schemaValue: [String: JSONValue] { get }
   var requiredKeys: [String] { get }
-  func validate(_ dictionary: [String: JSONValue]) -> Validated<Output, String>
+  func validate(_ dictionary: [String: JSONValue]) -> Parsed<Output, String>
 }
 
 public struct EmptyPropertyCollection: PropertyCollection {
   public let schemaValue: [String: JSONValue] = [:]
   public let requiredKeys: [String] = []
 
-  public func validate(_ dictionary: [String: JSONValue]) -> Validated<Void, String> { .valid(()) }
+  public func validate(_ dictionary: [String: JSONValue]) -> Parsed<Void, String> { .valid(()) }
 }
 
 public struct PropertyTuple<each Property: JSONPropertyComponent>: PropertyCollection {
@@ -77,7 +77,7 @@ public struct PropertyTuple<each Property: JSONPropertyComponent>: PropertyColle
 
   public func validate(
     _ dictionary: [String: JSONValue]
-  ) -> Validated<(repeat (each Property).Output), String> {
-    zip(repeat (each property).validate(dictionary))
+  ) -> Parsed<(repeat (each Property).Output), String> {
+    zip(repeat (each property).parse(dictionary))
   }
 }

--- a/Sources/JSONSchemaBuilder/Builders/JSONPropertySchemaBuilder.swift
+++ b/Sources/JSONSchemaBuilder/Builders/JSONPropertySchemaBuilder.swift
@@ -32,14 +32,14 @@ public protocol PropertyCollection: Sendable {
 
   var schemaValue: [String: JSONValue] { get }
   var requiredKeys: [String] { get }
-  func validate(_ dictionary: [String: JSONValue]) -> Parsed<Output, String>
+  func validate(_ dictionary: [String: JSONValue]) -> Parsed<Output, ParseIssue>
 }
 
 public struct EmptyPropertyCollection: PropertyCollection {
   public let schemaValue: [String: JSONValue] = [:]
   public let requiredKeys: [String] = []
 
-  public func validate(_ dictionary: [String: JSONValue]) -> Parsed<Void, String> { .valid(()) }
+  public func validate(_ dictionary: [String: JSONValue]) -> Parsed<Void, ParseIssue> { .valid(()) }
 }
 
 public struct PropertyTuple<each Property: JSONPropertyComponent>: PropertyCollection {
@@ -77,7 +77,7 @@ public struct PropertyTuple<each Property: JSONPropertyComponent>: PropertyColle
 
   public func validate(
     _ dictionary: [String: JSONValue]
-  ) -> Parsed<(repeat (each Property).Output), String> {
+  ) -> Parsed<(repeat (each Property).Output), ParseIssue> {
     zip(repeat (each property).parse(dictionary))
   }
 }

--- a/Sources/JSONSchemaBuilder/Documentation.docc/Articles/Validation.md
+++ b/Sources/JSONSchemaBuilder/Documentation.docc/Articles/Validation.md
@@ -26,10 +26,10 @@ let inStockSchema = JSONBoolean()
 To validate, pass an instance of `JSONValue` to the ``JSONSchemaComponent/validate(_:)``. The result is a ``Validated`` enum which will either by ``Validated/valid(_:)`` if the instance meets the schema constraints, or else ``Validated/invalid(_:)``.
 
 ```swift
-let id = identifierSchema.validate(.string("E621E1F8-C36C-495A-93FC-0C247A3E6E5F")) // Validated<String, String>
-let name = nameSchema.validate(.string("iPad")) // Validated<String, String>
-let price = priceSchema.validate(.number(199.99)) // Validated<Double, String>
-let inStock = inStockSchema.validate(.boolean(true)) // Validated<Bool, String>
+let id = identifierSchema.validate(.string("E621E1F8-C36C-495A-93FC-0C247A3E6E5F")) // Parsed<String, String>
+let name = nameSchema.validate(.string("iPad")) // Parsed<String, String>
+let price = priceSchema.validate(.number(199.99)) // Parsed<Double, String>
+let inStock = inStockSchema.validate(.boolean(true)) // Parsed<Bool, String>
 ```
 
 Notice that in the valid case, the first generic is a Swift primatives, not a `JSONValue` anymore. Of course, your instance is more likely to be a JSON string format.
@@ -57,7 +57,7 @@ let itemSchema = JSONObject {
 And now we are ready to validate.
 
 ```swift
-let itemValidationResult = itemSchema.validate(itemInstance) // Validated<(String?, String?, Double?, Bool?), String>
+let itemValidationResult = itemSchema.validate(itemInstance) // Parsed<(String?, String?, Double?, Bool?), String>
 switch itemValidationResult {
 case .valid(let value):
   print(value)
@@ -112,7 +112,7 @@ let newItemSchema = JSONObject {
 }
 .map(Item.init) // 3
 
-let item = newItemSchema.validate(itemInstance) // Validated<Item, String>
+let item = newItemSchema.validate(itemInstance) // Parsed<Item, String>
 ```
 
 1. Moved the schema definition inside the property builder with ``JSONProperty/init(key:builder:)``

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONAnyValue.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONAnyValue.swift
@@ -6,5 +6,5 @@ public struct JSONAnyValue: JSONSchemaComponent {
 
   public init() {}
 
-  public func parse(_ value: JSONValue) -> Parsed<JSONValue, String> { .valid(value) }
+  public func parse(_ value: JSONValue) -> Parsed<JSONValue, ParseIssue> { .valid(value) }
 }

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONAnyValue.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONAnyValue.swift
@@ -6,5 +6,5 @@ public struct JSONAnyValue: JSONSchemaComponent {
 
   public init() {}
 
-  public func parse(_ value: JSONValue) -> Validated<JSONValue, String> { .valid(value) }
+  public func parse(_ value: JSONValue) -> Parsed<JSONValue, String> { .valid(value) }
 }

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONBooleanSchema.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONBooleanSchema.swift
@@ -14,7 +14,7 @@ public struct JSONBooleanSchema: JSONSchemaComponent {
       .asSchema()
   }
 
-  public func parse(_ value: JSONValue) -> Validated<Bool, String> {
+  public func parse(_ value: JSONValue) -> Parsed<Bool, String> {
     self.value ? .valid(true) : .error("boolean schema false")
   }
 }

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONBooleanSchema.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONBooleanSchema.swift
@@ -14,8 +14,8 @@ public struct JSONBooleanSchema: JSONSchemaComponent {
       .asSchema()
   }
 
-  public func parse(_ value: JSONValue) -> Parsed<Bool, String> {
-    self.value ? .valid(true) : .error("boolean schema false")
+  public func parse(_ value: JSONValue) -> Parsed<Bool, ParseIssue> {
+    self.value ? .valid(true) : .error(.typeMismatch(expected: .boolean, actual: value))
   }
 }
 

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONComposition.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONComposition.swift
@@ -21,7 +21,7 @@ extension JSONComposableCollectionComponent where Output == JSONValue {
   ) { self.init(into: JSONValue.self, builder) }
 }
 
-public enum JSONComposition {
+public enum JSONComposition: Sendable {
   case anyOf
   case allOf
   case oneOf

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONComposition.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONComposition.swift
@@ -50,7 +50,9 @@ public enum JSONComposition {
         case .invalid(let errors): allErrors.append(contentsOf: errors)
         }
       }
-      return .error(.compositionFailure(type: .anyOf, reason: "did not match any", nestedErrors: allErrors))
+      return .error(
+        .compositionFailure(type: .anyOf, reason: "did not match any", nestedErrors: allErrors)
+      )
     }
   }
 
@@ -80,7 +82,13 @@ public enum JSONComposition {
       }
 
       guard let validResult, combinedErrors.isEmpty else {
-        return .error(.compositionFailure(type: .allOf, reason: "did not match all", nestedErrors: combinedErrors))
+        return .error(
+          .compositionFailure(
+            type: .allOf,
+            reason: "did not match all",
+            nestedErrors: combinedErrors
+          )
+        )
       }
       return .valid(validResult)
     }
@@ -116,10 +124,14 @@ public enum JSONComposition {
         return .valid(validResults.first!)
       } else if validResults.isEmpty {
         // No component validated successfully
-        return .error(.compositionFailure(type: .oneOf, reason: "no match found", nestedErrors: combinedErrors))
+        return .error(
+          .compositionFailure(type: .oneOf, reason: "no match found", nestedErrors: combinedErrors)
+        )
       } else {
         // More than one component validated successfully
-        return .error(.compositionFailure(type: .oneOf, reason: "multiple matches found", nestedErrors: []))
+        return .error(
+          .compositionFailure(type: .oneOf, reason: "multiple matches found", nestedErrors: [])
+        )
       }
     }
   }
@@ -137,7 +149,10 @@ public enum JSONComposition {
 
     public func parse(_ value: JSONValue) -> Parsed<JSONValue, ParseIssue> {
       switch component.parse(value) {
-      case .valid: return .error(.compositionFailure(type: .not, reason: "valid against not schema", nestedErrors: []))
+      case .valid:
+        return .error(
+          .compositionFailure(type: .not, reason: "valid against not schema", nestedErrors: [])
+        )
       case .invalid: return .valid(value)
       }
     }

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONComposition.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONComposition.swift
@@ -22,6 +22,11 @@ extension JSONComposableCollectionComponent where Output == JSONValue {
 }
 
 public enum JSONComposition {
+  case anyOf
+  case allOf
+  case oneOf
+  case not
+
   /// A component that accepts any of the given schemas.
   public struct AnyOf<Output>: JSONComposableCollectionComponent {
     public var schemaValue = [KeywordIdentifier: JSONValue]()
@@ -36,8 +41,8 @@ public enum JSONComposition {
       schemaValue[Keywords.AnyOf.name] = .array(components.map { .object($0.schemaValue) })
     }
 
-    public func parse(_ value: JSONValue) -> Parsed<Output, String> {
-      var allErrors: [String] = []
+    public func parse(_ value: JSONValue) -> Parsed<Output, ParseIssue> {
+      var allErrors: [ParseIssue] = []
 
       for component in components {
         switch component.parse(value) {
@@ -45,7 +50,7 @@ public enum JSONComposition {
         case .invalid(let errors): allErrors.append(contentsOf: errors)
         }
       }
-      return .invalid(["No valid component matched for value: \(value)"] + allErrors)
+      return .error(.compositionFailure(type: .anyOf, reason: "did not match any", nestedErrors: allErrors))
     }
   }
 
@@ -63,12 +68,8 @@ public enum JSONComposition {
       schemaValue[Keywords.AllOf.name] = .array(components.map { .object($0.schemaValue) })
     }
 
-    public func parse(_ value: JSONValue) -> Parsed<Output, String> {
-      guard !components.isEmpty else {
-        return .error("AllOf validation requires at least one schema component")
-      }
-
-      var combinedErrors: [String] = []
+    public func parse(_ value: JSONValue) -> Parsed<Output, ParseIssue> {
+      var combinedErrors: [ParseIssue] = []
       var validResult: Output?
 
       for component in components {
@@ -78,8 +79,8 @@ public enum JSONComposition {
         }
       }
 
-      guard let validResult = validResult, combinedErrors.isEmpty else {
-        return .invalid(["Failed AllOf validation"] + combinedErrors)
+      guard let validResult, combinedErrors.isEmpty else {
+        return .error(.compositionFailure(type: .allOf, reason: "did not match all", nestedErrors: combinedErrors))
       }
       return .valid(validResult)
     }
@@ -99,9 +100,9 @@ public enum JSONComposition {
       schemaValue[Keywords.OneOf.name] = .array(components.map { .object($0.schemaValue) })
     }
 
-    public func parse(_ value: JSONValue) -> Parsed<Output, String> {
+    public func parse(_ value: JSONValue) -> Parsed<Output, ParseIssue> {
       var validResults: [Output] = []
-      var combinedErrors: [String] = []
+      var combinedErrors: [ParseIssue] = []
 
       for component in components {
         switch component.parse(value) {
@@ -115,12 +116,10 @@ public enum JSONComposition {
         return .valid(validResults.first!)
       } else if validResults.isEmpty {
         // No component validated successfully
-        return .invalid(["Failed OneOf validation. No valid component matched."] + combinedErrors)
+        return .error(.compositionFailure(type: .oneOf, reason: "no match found", nestedErrors: combinedErrors))
       } else {
         // More than one component validated successfully
-        return .invalid([
-          "Failed OneOf validation. Multiple components matched, but exactly one is required."
-        ])
+        return .error(.compositionFailure(type: .oneOf, reason: "multiple matches found", nestedErrors: []))
       }
     }
   }
@@ -136,9 +135,9 @@ public enum JSONComposition {
       schemaValue[Keywords.Not.name] = .object(component.schemaValue)
     }
 
-    public func parse(_ value: JSONValue) -> Parsed<JSONValue, String> {
+    public func parse(_ value: JSONValue) -> Parsed<JSONValue, ParseIssue> {
       switch component.parse(value) {
-      case .valid: return .error("\(value) is valid against the not schema.")
+      case .valid: return .error(.compositionFailure(type: .not, reason: "valid against not schema", nestedErrors: []))
       case .invalid: return .valid(value)
       }
     }

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONComposition.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONComposition.swift
@@ -36,7 +36,7 @@ public enum JSONComposition {
       schemaValue[Keywords.AnyOf.name] = .array(components.map { .object($0.schemaValue) })
     }
 
-    public func parse(_ value: JSONValue) -> Validated<Output, String> {
+    public func parse(_ value: JSONValue) -> Parsed<Output, String> {
       var allErrors: [String] = []
 
       for component in components {
@@ -63,7 +63,7 @@ public enum JSONComposition {
       schemaValue[Keywords.AllOf.name] = .array(components.map { .object($0.schemaValue) })
     }
 
-    public func parse(_ value: JSONValue) -> Validated<Output, String> {
+    public func parse(_ value: JSONValue) -> Parsed<Output, String> {
       guard !components.isEmpty else {
         return .error("AllOf validation requires at least one schema component")
       }
@@ -99,7 +99,7 @@ public enum JSONComposition {
       schemaValue[Keywords.OneOf.name] = .array(components.map { .object($0.schemaValue) })
     }
 
-    public func parse(_ value: JSONValue) -> Validated<Output, String> {
+    public func parse(_ value: JSONValue) -> Parsed<Output, String> {
       var validResults: [Output] = []
       var combinedErrors: [String] = []
 
@@ -136,7 +136,7 @@ public enum JSONComposition {
       schemaValue[Keywords.Not.name] = .object(component.schemaValue)
     }
 
-    public func parse(_ value: JSONValue) -> Validated<JSONValue, String> {
+    public func parse(_ value: JSONValue) -> Parsed<JSONValue, String> {
       switch component.parse(value) {
       case .valid: return .error("\(value) is valid against the not schema.")
       case .invalid: return .valid(value)

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchema.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchema.swift
@@ -31,7 +31,7 @@ public struct JSONSchema<Components: JSONSchemaComponent, NewOutput>: JSONSchema
     self.components = component()
   }
 
-  public func parse(_ value: JSONValue) -> Validated<NewOutput, String> {
+  public func parse(_ value: JSONValue) -> Parsed<NewOutput, String> {
     components.parse(value).map(transform)
   }
 }

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchema.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchema.swift
@@ -31,7 +31,7 @@ public struct JSONSchema<Components: JSONSchemaComponent, NewOutput>: JSONSchema
     self.components = component()
   }
 
-  public func parse(_ value: JSONValue) -> Parsed<NewOutput, String> {
+  public func parse(_ value: JSONValue) -> Parsed<NewOutput, ParseIssue> {
     components.parse(value).map(transform)
   }
 }

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent.swift
@@ -10,7 +10,7 @@ public protocol JSONSchemaComponent<Output>: Sendable {
   /// Parse a JSON instance into a Swift type using the schema.
   /// - Parameter value: The value (aka instance or document) to validate.
   /// - Returns: A validated output or error messages.
-  @Sendable func parse(_ value: JSONValue) -> Validated<Output, String>
+  @Sendable func parse(_ value: JSONValue) -> Parsed<Output, String>
 }
 
 extension JSONSchemaComponent {
@@ -26,7 +26,7 @@ extension JSONSchemaComponent {
   public func parse(
     instance: String,
     decoder: JSONDecoder = JSONDecoder()
-  ) throws -> Validated<Output, String> {
+  ) throws -> Parsed<Output, String> {
     let value = try decoder.decode(JSONValue.self, from: Data(instance.utf8))
     return parse(value)
   }

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent.swift
@@ -10,7 +10,7 @@ public protocol JSONSchemaComponent<Output>: Sendable {
   /// Parse a JSON instance into a Swift type using the schema.
   /// - Parameter value: The value (aka instance or document) to validate.
   /// - Returns: A validated output or error messages.
-  @Sendable func parse(_ value: JSONValue) -> Parsed<Output, String>
+  @Sendable func parse(_ value: JSONValue) -> Parsed<Output, ParseIssue>
 }
 
 extension JSONSchemaComponent {
@@ -26,7 +26,7 @@ extension JSONSchemaComponent {
   public func parse(
     instance: String,
     decoder: JSONDecoder = JSONDecoder()
-  ) throws -> Parsed<Output, String> {
+  ) throws -> Parsed<Output, ParseIssue> {
     let value = try decoder.decode(JSONValue.self, from: Data(instance.utf8))
     return parse(value)
   }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/AdditionalProperties.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/AdditionalProperties.swift
@@ -19,7 +19,7 @@ extension JSONComponents {
 
     public func parse(
       _ input: JSONValue
-    ) -> Validated<(Props.Output, [String: AdditionalProps.Output]), String> {
+    ) -> Parsed<(Props.Output, [String: AdditionalProps.Output]), String> {
       guard case .object(let dictionary) = input else { return .error("Not an object") }
 
       // Validate the base properties

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/AdditionalProperties.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/AdditionalProperties.swift
@@ -19,8 +19,8 @@ extension JSONComponents {
 
     public func parse(
       _ input: JSONValue
-    ) -> Parsed<(Props.Output, [String: AdditionalProps.Output]), String> {
-      guard case .object(let dictionary) = input else { return .error("Not an object") }
+    ) -> Parsed<(Props.Output, [String: AdditionalProps.Output]), ParseIssue> {
+      guard case .object(let dictionary) = input else { return .error(.typeMismatch(expected: .object, actual: input)) }
 
       // Validate the base properties
       let baseValidation = base.parse(input)

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/AdditionalProperties.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/AdditionalProperties.swift
@@ -20,7 +20,9 @@ extension JSONComponents {
     public func parse(
       _ input: JSONValue
     ) -> Parsed<(Props.Output, [String: AdditionalProps.Output]), ParseIssue> {
-      guard case .object(let dictionary) = input else { return .error(.typeMismatch(expected: .object, actual: input)) }
+      guard case .object(let dictionary) = input else {
+        return .error(.typeMismatch(expected: .object, actual: input))
+      }
 
       // Validate the base properties
       let baseValidation = base.parse(input)

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Any.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Any.swift
@@ -7,7 +7,7 @@ extension JSONSchemaComponent {
 extension JSONComponents {
   /// Component for type erasure.
   public struct AnyComponent<Output>: JSONSchemaComponent {
-    private let validate: @Sendable (JSONValue) -> Validated<Output, String>
+    private let validate: @Sendable (JSONValue) -> Parsed<Output, String>
     public var schemaValue: [KeywordIdentifier: JSONValue]
 
     public init<Component: JSONSchemaComponent>(_ component: Component)
@@ -16,6 +16,6 @@ extension JSONComponents {
       self.validate = component.parse
     }
 
-    public func parse(_ value: JSONValue) -> Validated<Output, String> { validate(value) }
+    public func parse(_ value: JSONValue) -> Parsed<Output, String> { validate(value) }
   }
 }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Any.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Any.swift
@@ -7,7 +7,7 @@ extension JSONSchemaComponent {
 extension JSONComponents {
   /// Component for type erasure.
   public struct AnyComponent<Output>: JSONSchemaComponent {
-    private let validate: @Sendable (JSONValue) -> Parsed<Output, String>
+    private let validate: @Sendable (JSONValue) -> Parsed<Output, ParseIssue>
     public var schemaValue: [KeywordIdentifier: JSONValue]
 
     public init<Component: JSONSchemaComponent>(_ component: Component)
@@ -16,6 +16,6 @@ extension JSONComponents {
       self.validate = component.parse
     }
 
-    public func parse(_ value: JSONValue) -> Parsed<Output, String> { validate(value) }
+    public func parse(_ value: JSONValue) -> Parsed<Output, ParseIssue> { validate(value) }
   }
 }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/CompactMap.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/CompactMap.swift
@@ -24,7 +24,7 @@ extension JSONComponents {
       self.transform = transform
     }
 
-    public func parse(_ value: JSONValue) -> Validated<Output, String> {
+    public func parse(_ value: JSONValue) -> Parsed<Output, String> {
       let output = upstream.parse(value)
       switch output {
       case .valid(let a):

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/CompactMap.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/CompactMap.swift
@@ -24,11 +24,11 @@ extension JSONComponents {
       self.transform = transform
     }
 
-    public func parse(_ value: JSONValue) -> Parsed<Output, String> {
+    public func parse(_ value: JSONValue) -> Parsed<Output, ParseIssue> {
       let output = upstream.parse(value)
       switch output {
       case .valid(let a):
-        guard let newOutput = transform(a) else { return .error("failed to process from \(value)") }
+        guard let newOutput = transform(a) else { return .error(.compactMapValueNil(value: value)) }
         return .valid(newOutput)
       case .invalid(let errors): return .invalid(errors)
       }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Conditional.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Conditional.swift
@@ -23,7 +23,7 @@ extension JSONComponents {
     case first(First)
     case second(Second)
 
-    public func parse(_ value: JSONValue) -> Validated<First.Output, String> {
+    public func parse(_ value: JSONValue) -> Parsed<First.Output, String> {
       switch self {
       case .first(let first): return first.parse(value)
       case .second(let second): return second.parse(value)

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Conditional.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Conditional.swift
@@ -23,7 +23,7 @@ extension JSONComponents {
     case first(First)
     case second(Second)
 
-    public func parse(_ value: JSONValue) -> Parsed<First.Output, String> {
+    public func parse(_ value: JSONValue) -> Parsed<First.Output, ParseIssue> {
       switch self {
       case .first(let first): return first.parse(value)
       case .second(let second): return second.parse(value)

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Enum.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Enum.swift
@@ -28,7 +28,7 @@ extension JSONComponents {
 
     }
 
-    public func parse(_ value: JSONValue) -> Validated<Upstream.Output, String> {
+    public func parse(_ value: JSONValue) -> Parsed<Upstream.Output, String> {
       for `case` in cases where `case` == value { return upstream.parse(value) }
       return .error("\(value) does not match any enum case.")
     }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Enum.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Enum.swift
@@ -28,9 +28,9 @@ extension JSONComponents {
 
     }
 
-    public func parse(_ value: JSONValue) -> Parsed<Upstream.Output, String> {
+    public func parse(_ value: JSONValue) -> Parsed<Upstream.Output, ParseIssue> {
       for `case` in cases where `case` == value { return upstream.parse(value) }
-      return .error("\(value) does not match any enum case.")
+      return .error(.noEnumCaseMatch(value: value))
     }
   }
 }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/FlatMap.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/FlatMap.swift
@@ -27,7 +27,7 @@ extension JSONComponents {
       self.transform = transform
     }
 
-    public func parse(_ value: JSONValue) -> Parsed<NewSchemaComponent.Output, String> {
+    public func parse(_ value: JSONValue) -> Parsed<NewSchemaComponent.Output, ParseIssue> {
       switch upstream.parse(value) {
       case .valid(let upstreamOutput):
         let newSchemaComponent = transform(upstreamOutput)

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/FlatMap.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/FlatMap.swift
@@ -27,7 +27,7 @@ extension JSONComponents {
       self.transform = transform
     }
 
-    public func parse(_ value: JSONValue) -> Validated<NewSchemaComponent.Output, String> {
+    public func parse(_ value: JSONValue) -> Parsed<NewSchemaComponent.Output, String> {
       switch upstream.parse(value) {
       case .valid(let upstreamOutput):
         let newSchemaComponent = transform(upstreamOutput)

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Map.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Map.swift
@@ -24,7 +24,7 @@ extension JSONComponents {
       self.transform = transform
     }
 
-    public func parse(_ value: JSONValue) -> Parsed<NewOutput, String> {
+    public func parse(_ value: JSONValue) -> Parsed<NewOutput, ParseIssue> {
       upstream.parse(value).map(transform)
     }
   }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Map.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Map.swift
@@ -24,7 +24,7 @@ extension JSONComponents {
       self.transform = transform
     }
 
-    public func parse(_ value: JSONValue) -> Validated<NewOutput, String> {
+    public func parse(_ value: JSONValue) -> Parsed<NewOutput, String> {
       upstream.parse(value).map(transform)
     }
   }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Optional.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Optional.swift
@@ -13,7 +13,7 @@ extension JSONComponents {
 
     public init(wrapped: Wrapped?) { self.wrapped = wrapped }
 
-    public func parse(_ value: JSONValue) -> Validated<Wrapped.Output?, String> {
+    public func parse(_ value: JSONValue) -> Parsed<Wrapped.Output?, String> {
       guard let wrapped else { return .valid(nil) }
       return wrapped.parse(value).map(Optional.some)
     }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Optional.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Optional.swift
@@ -13,7 +13,7 @@ extension JSONComponents {
 
     public init(wrapped: Wrapped?) { self.wrapped = wrapped }
 
-    public func parse(_ value: JSONValue) -> Parsed<Wrapped.Output?, String> {
+    public func parse(_ value: JSONValue) -> Parsed<Wrapped.Output?, ParseIssue> {
       guard let wrapped else { return .valid(nil) }
       return wrapped.parse(value).map(Optional.some)
     }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Passthrough.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Passthrough.swift
@@ -13,7 +13,7 @@ extension JSONComponents {
 
     public init(wrapped: Component) { self.wrapped = wrapped }
 
-    public func parse(_ value: JSONValue) -> Validated<JSONValue, String> {
+    public func parse(_ value: JSONValue) -> Parsed<JSONValue, String> {
       wrapped.parse(value)
         .flatMap { _ in .valid(value)  // Ignore valid associated type and pass original string
         }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Passthrough.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Passthrough.swift
@@ -13,7 +13,7 @@ extension JSONComponents {
 
     public init(wrapped: Component) { self.wrapped = wrapped }
 
-    public func parse(_ value: JSONValue) -> Parsed<JSONValue, String> {
+    public func parse(_ value: JSONValue) -> Parsed<JSONValue, ParseIssue> {
       wrapped.parse(value)
         .flatMap { _ in .valid(value)  // Ignore valid associated type and pass original string
         }

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONArray.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONArray.swift
@@ -24,10 +24,10 @@ public struct JSONArray<T: JSONSchemaComponent>: JSONSchemaComponent {
     }
   }
 
-  public func parse(_ value: JSONValue) -> Parsed<[T.Output], String> {
+  public func parse(_ value: JSONValue) -> Parsed<[T.Output], ParseIssue> {
     if case .array(let array) = value {
       var outputs: [T.Output] = []
-      var errors: [String] = []
+      var errors: [ParseIssue] = []
       for item in array {
         switch items.parse(item) {
         case .valid(let value): outputs.append(value)
@@ -37,7 +37,7 @@ public struct JSONArray<T: JSONSchemaComponent>: JSONSchemaComponent {
       guard !errors.isEmpty else { return .valid(outputs) }
       return .invalid(errors)
     }
-    return .error("Expected array value")
+    return .error(.typeMismatch(expected: .array, actual: value))
   }
 }
 

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONArray.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONArray.swift
@@ -24,7 +24,7 @@ public struct JSONArray<T: JSONSchemaComponent>: JSONSchemaComponent {
     }
   }
 
-  public func parse(_ value: JSONValue) -> Validated<[T.Output], String> {
+  public func parse(_ value: JSONValue) -> Parsed<[T.Output], String> {
     if case .array(let array) = value {
       var outputs: [T.Output] = []
       var errors: [String] = []

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONBoolean.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONBoolean.swift
@@ -8,7 +8,7 @@ public struct JSONBoolean: JSONSchemaComponent {
 
   public init() {}
 
-  public func parse(_ value: JSONValue) -> Validated<Bool, String> {
+  public func parse(_ value: JSONValue) -> Parsed<Bool, String> {
     if case .boolean(let bool) = value { return .valid(bool) }
     return .error("Expected a boolean value.")
   }

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONBoolean.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONBoolean.swift
@@ -8,8 +8,8 @@ public struct JSONBoolean: JSONSchemaComponent {
 
   public init() {}
 
-  public func parse(_ value: JSONValue) -> Parsed<Bool, String> {
+  public func parse(_ value: JSONValue) -> Parsed<Bool, ParseIssue> {
     if case .boolean(let bool) = value { return .valid(bool) }
-    return .error("Expected a boolean value.")
+    return .error(.typeMismatch(expected: .boolean, actual: value))
   }
 }

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONNull.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONNull.swift
@@ -8,8 +8,8 @@ public struct JSONNull: JSONSchemaComponent {
 
   public init() {}
 
-  public func parse(_ value: JSONValue) -> Parsed<Void, String> {
+  public func parse(_ value: JSONValue) -> Parsed<Void, ParseIssue> {
     if case .null = value { return .valid(()) }
-    return .error("Expected null value, but got \(value)")
+    return .error(.typeMismatch(expected: .null, actual: value))
   }
 }

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONNull.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONNull.swift
@@ -8,7 +8,7 @@ public struct JSONNull: JSONSchemaComponent {
 
   public init() {}
 
-  public func parse(_ value: JSONValue) -> Validated<Void, String> {
+  public func parse(_ value: JSONValue) -> Parsed<Void, String> {
     if case .null = value { return .valid(()) }
     return .error("Expected null value, but got \(value)")
   }

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONNumber.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONNumber.swift
@@ -10,7 +10,7 @@ public struct JSONInteger: JSONNumberType {
     schemaValue[Keywords.TypeKeyword.name] = .string(JSONType.integer.rawValue)
   }
 
-  public func parse(_ value: JSONValue) -> Validated<Int, String> {
+  public func parse(_ value: JSONValue) -> Parsed<Int, String> {
     if case .integer(let int) = value { return .valid(int) }
     return .error("Expected integer value.")
   }
@@ -24,7 +24,7 @@ public struct JSONNumber: JSONNumberType {
     schemaValue[Keywords.TypeKeyword.name] = .string(JSONType.number.rawValue)
   }
 
-  public func parse(_ value: JSONValue) -> Validated<Double, String> {
+  public func parse(_ value: JSONValue) -> Parsed<Double, String> {
     if case .number(let double) = value { return .valid(double) }
     return .error("Expected a number.")
   }

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONNumber.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONNumber.swift
@@ -10,9 +10,9 @@ public struct JSONInteger: JSONNumberType {
     schemaValue[Keywords.TypeKeyword.name] = .string(JSONType.integer.rawValue)
   }
 
-  public func parse(_ value: JSONValue) -> Parsed<Int, String> {
+  public func parse(_ value: JSONValue) -> Parsed<Int, ParseIssue> {
     if case .integer(let int) = value { return .valid(int) }
-    return .error("Expected integer value.")
+    return .error(.typeMismatch(expected: .integer, actual: value))
   }
 }
 
@@ -24,9 +24,9 @@ public struct JSONNumber: JSONNumberType {
     schemaValue[Keywords.TypeKeyword.name] = .string(JSONType.number.rawValue)
   }
 
-  public func parse(_ value: JSONValue) -> Parsed<Double, String> {
+  public func parse(_ value: JSONValue) -> Parsed<Double, ParseIssue> {
     if case .number(let double) = value { return .valid(double) }
-    return .error("Expected a number.")
+    return .error(.typeMismatch(expected: .number, actual: value))
   }
 }
 

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONObject.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONObject.swift
@@ -31,7 +31,7 @@ public struct JSONObject<Props: PropertyCollection>: JSONSchemaComponent {
   /// Creates a new `JSONObject` with no property requirements.
   public init() where Props == EmptyPropertyCollection { self.init(with: {}) }
 
-  public func parse(_ input: JSONValue) -> Validated<Props.Output, String> {
+  public func parse(_ input: JSONValue) -> Parsed<Props.Output, String> {
     if case .object(let dictionary) = input { return properties.validate(dictionary) }
     return .error("Not an object")
   }

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONObject.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONObject.swift
@@ -31,9 +31,9 @@ public struct JSONObject<Props: PropertyCollection>: JSONSchemaComponent {
   /// Creates a new `JSONObject` with no property requirements.
   public init() where Props == EmptyPropertyCollection { self.init(with: {}) }
 
-  public func parse(_ input: JSONValue) -> Parsed<Props.Output, String> {
+  public func parse(_ input: JSONValue) -> Parsed<Props.Output, ParseIssue> {
     if case .object(let dictionary) = input { return properties.validate(dictionary) }
-    return .error("Not an object")
+    return .error(.typeMismatch(expected: .object, actual: input))
   }
 }
 

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONObject.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONObject.swift
@@ -58,7 +58,7 @@ extension JSONObject {
   ///     JSONString()
   ///   }
   /// ```
-  /// `myObj.validate(/* some input */)` will have a type of `Validated<(Void, String), String>`
+  /// `myObj.validate(/* some input */)` will have a type of `Parsed<(Void, String), String>`
   ///
   /// For now, to drop the `Void`, you can add a map, like `.map { $1 }`.
   /// TODO: Drop `Void` values from tuple with builder.

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONString.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONString.swift
@@ -8,7 +8,7 @@ public struct JSONString: JSONSchemaComponent {
     schemaValue[Keywords.TypeKeyword.name] = .string(JSONType.string.rawValue)
   }
 
-  public func parse(_ value: JSONValue) -> Validated<String, String> {
+  public func parse(_ value: JSONValue) -> Parsed<String, String> {
     if case .string(let string) = value { return .valid(string) }
     return .error("Expected a string value.")
   }

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONString.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONString.swift
@@ -8,9 +8,9 @@ public struct JSONString: JSONSchemaComponent {
     schemaValue[Keywords.TypeKeyword.name] = .string(JSONType.string.rawValue)
   }
 
-  public func parse(_ value: JSONValue) -> Parsed<String, String> {
+  public func parse(_ value: JSONValue) -> Parsed<String, ParseIssue> {
     if case .string(let string) = value { return .valid(string) }
-    return .error("Expected a string value.")
+    return .error(.typeMismatch(expected: .string, actual: value))
   }
 }
 

--- a/Sources/JSONSchemaBuilder/JSONPropertyComponent/JSONProperty.swift
+++ b/Sources/JSONSchemaBuilder/JSONPropertyComponent/JSONProperty.swift
@@ -35,7 +35,7 @@ public struct JSONProperty<Value: JSONSchemaComponent>: JSONPropertyComponent {
     self.value = JSONAnyValue()
   }
 
-  public func parse(_ input: [String: JSONValue]) -> Parsed<Value.Output?, String> {
+  public func parse(_ input: [String: JSONValue]) -> Parsed<Value.Output?, ParseIssue> {
     if let jsonValue = input[key] { return value.parse(jsonValue).map(Optional.some) }
     return .valid(nil)
   }

--- a/Sources/JSONSchemaBuilder/JSONPropertyComponent/JSONProperty.swift
+++ b/Sources/JSONSchemaBuilder/JSONPropertyComponent/JSONProperty.swift
@@ -35,7 +35,7 @@ public struct JSONProperty<Value: JSONSchemaComponent>: JSONPropertyComponent {
     self.value = JSONAnyValue()
   }
 
-  public func validate(_ input: [String: JSONValue]) -> Validated<Value.Output?, String> {
+  public func parse(_ input: [String: JSONValue]) -> Parsed<Value.Output?, String> {
     if let jsonValue = input[key] { return value.parse(jsonValue).map(Optional.some) }
     return .valid(nil)
   }

--- a/Sources/JSONSchemaBuilder/JSONPropertyComponent/JSONPropertyComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONPropertyComponent/JSONPropertyComponent.swift
@@ -10,5 +10,5 @@ public protocol JSONPropertyComponent: Sendable {
   var isRequired: Bool { get }
   var value: Value { get }
 
-  func parse(_ input: [String: JSONValue]) -> Parsed<Output, String>
+  func parse(_ input: [String: JSONValue]) -> Parsed<Output, ParseIssue>
 }

--- a/Sources/JSONSchemaBuilder/JSONPropertyComponent/JSONPropertyComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONPropertyComponent/JSONPropertyComponent.swift
@@ -10,5 +10,5 @@ public protocol JSONPropertyComponent: Sendable {
   var isRequired: Bool { get }
   var value: Value { get }
 
-  func validate(_ input: [String: JSONValue]) -> Validated<Output, String>
+  func parse(_ input: [String: JSONValue]) -> Parsed<Output, String>
 }

--- a/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyCompactMap.swift
+++ b/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyCompactMap.swift
@@ -23,8 +23,8 @@ extension JSONPropertyComponents {
 
     public var value: Upstream.Value { upstream.value }
 
-    public func validate(_ input: [String: JSONValue]) -> Validated<NewOutput, String> {
-      switch upstream.validate(input) {
+    public func parse(_ input: [String: JSONValue]) -> Parsed<NewOutput, String> {
+      switch upstream.parse(input) {
       case .valid(let output):
         guard let newOutput = transform(output) else {
           return .error("Transformation failed for key: \(key)")

--- a/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyCompactMap.swift
+++ b/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyCompactMap.swift
@@ -23,11 +23,13 @@ extension JSONPropertyComponents {
 
     public var value: Upstream.Value { upstream.value }
 
-    public func parse(_ input: [String: JSONValue]) -> Parsed<NewOutput, String> {
+    public func parse(_ input: [String: JSONValue]) -> Parsed<NewOutput, ParseIssue> {
       switch upstream.parse(input) {
       case .valid(let output):
         guard let newOutput = transform(output) else {
-          return .error("Transformation failed for key: \(key)")
+          // TODO: This isn't as generic as `compactMap` concept and leaks usage.
+          // Would be better to use a closure for ParseIssue or change transform closure?
+          return .error(.missingRequiredProperty(property: key))
         }
         return .valid(newOutput)
       case .invalid(let error): return .invalid(error)

--- a/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyConditional.swift
+++ b/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyConditional.swift
@@ -21,7 +21,7 @@ extension JSONPropertyComponents {
     case first(First)
     case second(Second)
 
-    public func validate(_ input: [String: JSONValue]) -> Validated<First.Output, String> {
+    public func validate(_ input: [String: JSONValue]) -> Parsed<First.Output, String> {
       switch self {
       case .first(let first): first.validate(input)
       case .second(let second): second.validate(input)

--- a/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyConditional.swift
+++ b/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyConditional.swift
@@ -21,7 +21,7 @@ extension JSONPropertyComponents {
     case first(First)
     case second(Second)
 
-    public func validate(_ input: [String: JSONValue]) -> Parsed<First.Output, String> {
+    public func validate(_ input: [String: JSONValue]) -> Parsed<First.Output, ParseIssue> {
       switch self {
       case .first(let first): first.validate(input)
       case .second(let second): second.validate(input)

--- a/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyOptional.swift
+++ b/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyOptional.swift
@@ -11,7 +11,7 @@ extension JSONPropertyComponents {
 
     public init(wrapped: Wrapped?) { self.wrapped = wrapped }
 
-    public func validate(_ input: [String: JSONValue]) -> Parsed<Wrapped.Output?, String> {
+    public func validate(_ input: [String: JSONValue]) -> Parsed<Wrapped.Output?, ParseIssue> {
       wrapped?.validate(input).map(Optional.some) ?? .valid(nil)
     }
   }

--- a/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyOptional.swift
+++ b/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyOptional.swift
@@ -11,7 +11,7 @@ extension JSONPropertyComponents {
 
     public init(wrapped: Wrapped?) { self.wrapped = wrapped }
 
-    public func validate(_ input: [String: JSONValue]) -> Validated<Wrapped.Output?, String> {
+    public func validate(_ input: [String: JSONValue]) -> Parsed<Wrapped.Output?, String> {
       wrapped?.validate(input).map(Optional.some) ?? .valid(nil)
     }
   }

--- a/Sources/JSONSchemaBuilder/Parsing/ParseIssue.swift
+++ b/Sources/JSONSchemaBuilder/Parsing/ParseIssue.swift
@@ -1,6 +1,6 @@
 import JSONSchema
 
-public enum ParseIssue: Equatable {
+public enum ParseIssue: Equatable, Sendable {
   case typeMismatch(expected: JSONType, actual: JSONValue)
   case noEnumCaseMatch(value: JSONValue)
   case missingRequiredProperty(property: String)

--- a/Sources/JSONSchemaBuilder/Parsing/ParseIssue.swift
+++ b/Sources/JSONSchemaBuilder/Parsing/ParseIssue.swift
@@ -1,0 +1,9 @@
+import JSONSchema
+
+public enum ParseIssue: Equatable {
+  case typeMismatch(expected: JSONType, actual: JSONValue)
+  case noEnumCaseMatch(value: JSONValue)
+  case missingRequiredProperty(property: String)
+  case compactMapValueNil(value: JSONValue)
+  case compositionFailure(type: JSONComposition, reason: String, nestedErrors: [ParseIssue])
+}

--- a/Sources/JSONSchemaBuilder/Parsing/Parsed.swift
+++ b/Sources/JSONSchemaBuilder/Parsing/Parsed.swift
@@ -1,6 +1,6 @@
 /// Similar to `Result` from Swift but `invalid` case has an array of errors.
 /// Adapted from [Point-Free](https://github.com/pointfreeco/swift-validated) to use variadic parameters.
-public enum Validated<Value, Error> {
+public enum Parsed<Value, Error> {
   case valid(Value)
   case invalid([Error])
 
@@ -8,7 +8,7 @@ public enum Validated<Value, Error> {
 
   public func map<ValueOfResult>(
     _ transform: (Value) -> ValueOfResult
-  ) -> Validated<ValueOfResult, Error> {
+  ) -> Parsed<ValueOfResult, Error> {
     switch self {
     case .valid(let value): return .valid(transform(value))
     case .invalid(let errors): return .invalid(errors)
@@ -16,8 +16,8 @@ public enum Validated<Value, Error> {
   }
 
   public func flatMap<ValueOfResult>(
-    _ transform: (Value) -> Validated<ValueOfResult, Error>
-  ) -> Validated<ValueOfResult, Error> {
+    _ transform: (Value) -> Parsed<ValueOfResult, Error>
+  ) -> Parsed<ValueOfResult, Error> {
     switch self {
     case .valid(let value): return transform(value)
     case .invalid(let errors): return .invalid(errors)
@@ -39,7 +39,7 @@ public enum Validated<Value, Error> {
   }
 }
 
-extension Validated: Equatable where Value: Equatable, Error: Equatable {}
+extension Parsed: Equatable where Value: Equatable, Error: Equatable {}
 
 struct Invalid: Error {}
 
@@ -47,9 +47,9 @@ struct Invalid: Error {}
 /// Example:
 /// `zip(Validated<A, E>, Validated<B, E>, Validated<C, E>)` -> `Validated<(A, B, C), E>`
 public func zip<each Value, Error>(
-  _ validated: repeat Validated<each Value, Error>
-) -> Validated<(repeat each Value), Error> {
-  func valid<V>(_ v: Validated<V, Error>) throws -> V {
+  _ validated: repeat Parsed<each Value, Error>
+) -> Parsed<(repeat each Value), Error> {
+  func valid<V>(_ v: Parsed<V, Error>) throws -> V {
     switch v {
     case .valid(let x): return x
     case .invalid:
@@ -74,7 +74,7 @@ public func zip<each Value, Error>(
         }
       }
     #else
-      func collectErrors<Val>(_ v: Validated<Val, Error>) {
+      func collectErrors<Val>(_ v: Parsed<Val, Error>) {
         switch v {
         case .valid: break
         case .invalid(let array): errors.append(contentsOf: array)

--- a/Sources/JSONSchemaBuilder/Parsing/Parsed.swift
+++ b/Sources/JSONSchemaBuilder/Parsing/Parsed.swift
@@ -45,7 +45,7 @@ struct Invalid: Error {}
 
 /// Combine values of Validated together into a tuple.
 /// Example:
-/// `zip(Validated<A, E>, Validated<B, E>, Validated<C, E>)` -> `Validated<(A, B, C), E>`
+/// `zip(Parsed<A, E>, Parsed<B, E>, Parsed<C, E>)` -> `Parsed<(A, B, C), E>`
 public func zip<each Value, Error>(
   _ validated: repeat Parsed<each Value, Error>
 ) -> Parsed<(repeat each Value), Error> {

--- a/Sources/JSONSchemaClient/main.swift
+++ b/Sources/JSONSchemaClient/main.swift
@@ -74,18 +74,3 @@ let result1 = schema.validate(instance1)
 dump(result1, name: "Instance 1 Validation Result")
 let result2 = schema.validate(instance2)
 dump(result2, name: "Instance 2 Validation Result")
-
-let schemaString = """
-  {
-    "type": "object",
-    "properties": {
-      "name": {
-        "type": "string",
-        "minLength": 1
-      }
-    }
-  }
-  """
-let schema1 = try Schema(instance: schemaString, dialect: .draft2020_12)
-let result = try schema1.validate(instance: #"{"name": "Alice"}"#)
-schema1

--- a/Tests/JSONSchemaIntegrationTests/PollExampleTests.swift
+++ b/Tests/JSONSchemaIntegrationTests/PollExampleTests.swift
@@ -308,4 +308,17 @@ struct PollExampleTests {
     // assertSnapshot(of: validationResult.sorted(), as: .json)
     #expect(instance.isValid == validationResult.isValid)
   }
+
+  @Test(arguments: instances)
+  func parseAndValidate(instance: TestInstance) throws {
+    if instance.isValid && instance.shouldParse {
+      #expect(throws: Never.self) {
+        _ = try Poll.schema.parseAndValidate(instance: instance.data)
+      }
+    } else {
+      #expect(throws: ParseAndValidateIssue.self) {
+        _ = try Poll.schema.parseAndValidate(instance: instance.data)
+      }
+    }
+  }
 }

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.1.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.1.txt
@@ -1,4 +1,4 @@
-▿ Parsed<Poll, String>
+▿ Parsed<Poll, ParseIssue>
   ▿ valid: Poll
     ▿ category: Category
       ▿ technology: Technology

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.1.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.1.txt
@@ -1,4 +1,4 @@
-▿ Validated<Poll, String>
+▿ Parsed<Poll, String>
   ▿ valid: Poll
     ▿ category: Category
       ▿ technology: Technology

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.2.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.2.txt
@@ -1,4 +1,4 @@
-▿ Parsed<Poll, String>
+▿ Parsed<Poll, ParseIssue>
   ▿ valid: Poll
     ▿ category: Category
       ▿ entertainment: Entertainment

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.2.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.2.txt
@@ -1,4 +1,4 @@
-▿ Validated<Poll, String>
+▿ Parsed<Poll, String>
   ▿ valid: Poll
     ▿ category: Category
       ▿ entertainment: Entertainment

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.3.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.3.txt
@@ -1,4 +1,4 @@
-▿ Validated<Poll, String>
+▿ Parsed<Poll, String>
   ▿ valid: Poll
     - category: Category.sports
     - createdAt: "2024-10-25T15:00:00Z"

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.3.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.3.txt
@@ -1,4 +1,4 @@
-▿ Parsed<Poll, String>
+▿ Parsed<Poll, ParseIssue>
   ▿ valid: Poll
     - category: Category.sports
     - createdAt: "2024-10-25T15:00:00Z"

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.4.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.4.txt
@@ -1,3 +1,3 @@
-▿ Parsed<Poll, String>
+▿ Parsed<Poll, ParseIssue>
   ▿ invalid: 1 element
     - "Transformation failed for key: title"

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.4.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.4.txt
@@ -1,3 +1,5 @@
 ▿ Parsed<Poll, ParseIssue>
   ▿ invalid: 1 element
-    - "Transformation failed for key: title"
+    ▿ ParseIssue
+      ▿ missingRequiredProperty: (1 element)
+        - property: "title"

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.4.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.4.txt
@@ -1,3 +1,3 @@
-▿ Validated<Poll, String>
+▿ Parsed<Poll, String>
   ▿ invalid: 1 element
     - "Transformation failed for key: title"

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.5.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.5.txt
@@ -1,4 +1,4 @@
-▿ Validated<Poll, String>
+▿ Parsed<Poll, String>
   ▿ invalid: 5 elements
     - "No valid component matched for value: object([\"food\": JSONSchema.JSONValue.object([\"_0\": JSONSchema.JSONValue.object([\"customDescription\": JSONSchema.JSONValue.string(\"What\\\'s your favorite?\")])])])"
     - "Transformation failed for key: technology"

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.5.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.5.txt
@@ -1,7 +1,32 @@
 ▿ Parsed<Poll, ParseIssue>
-  ▿ invalid: 5 elements
-    - "No valid component matched for value: object([\"food\": JSONSchema.JSONValue.object([\"_0\": JSONSchema.JSONValue.object([\"customDescription\": JSONSchema.JSONValue.string(\"What\\\'s your favorite?\")])])])"
-    - "Transformation failed for key: technology"
-    - "Transformation failed for key: entertainment"
-    - "Transformation failed for key: education"
-    - "object([\"food\": JSONSchema.JSONValue.object([\"_0\": JSONSchema.JSONValue.object([\"customDescription\": JSONSchema.JSONValue.string(\"What\\\'s your favorite?\")])])]) does not match any enum case."
+  ▿ invalid: 1 element
+    ▿ ParseIssue
+      ▿ compositionFailure: (3 elements)
+        - type: JSONComposition.anyOf
+        - reason: "did not match any"
+        ▿ nestedErrors: 4 elements
+          ▿ ParseIssue
+            ▿ missingRequiredProperty: (1 element)
+              - property: "technology"
+          ▿ ParseIssue
+            ▿ missingRequiredProperty: (1 element)
+              - property: "entertainment"
+          ▿ ParseIssue
+            ▿ missingRequiredProperty: (1 element)
+              - property: "education"
+          ▿ ParseIssue
+            ▿ noEnumCaseMatch: (1 element)
+              ▿ value: JSONValue
+                ▿ object: 1 key/value pair
+                  ▿ (2 elements)
+                    - key: "food"
+                    ▿ value: JSONValue
+                      ▿ object: 1 key/value pair
+                        ▿ (2 elements)
+                          - key: "_0"
+                          ▿ value: JSONValue
+                            ▿ object: 1 key/value pair
+                              ▿ (2 elements)
+                                - key: "customDescription"
+                                ▿ value: JSONValue
+                                  - string: "What\'s your favorite?"

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.5.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.5.txt
@@ -1,4 +1,4 @@
-▿ Parsed<Poll, String>
+▿ Parsed<Poll, ParseIssue>
   ▿ invalid: 5 elements
     - "No valid component matched for value: object([\"food\": JSONSchema.JSONValue.object([\"_0\": JSONSchema.JSONValue.object([\"customDescription\": JSONSchema.JSONValue.string(\"What\\\'s your favorite?\")])])])"
     - "Transformation failed for key: technology"

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.6.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.6.txt
@@ -1,4 +1,4 @@
-▿ Parsed<Poll, String>
+▿ Parsed<Poll, ParseIssue>
   ▿ valid: Poll
     - category: Category.other
     - createdAt: "2024-10-25T12:00:00Z"

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.6.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.6.txt
@@ -1,4 +1,4 @@
-▿ Validated<Poll, String>
+▿ Parsed<Poll, String>
   ▿ valid: Poll
     - category: Category.other
     - createdAt: "2024-10-25T12:00:00Z"

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.7.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.7.txt
@@ -1,4 +1,4 @@
-▿ Validated<Poll, String>
+▿ Parsed<Poll, String>
   ▿ valid: Poll
     - category: Category.other
     - createdAt: "invalid-date"

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.7.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.7.txt
@@ -1,4 +1,4 @@
-▿ Parsed<Poll, String>
+▿ Parsed<Poll, ParseIssue>
   ▿ valid: Poll
     - category: Category.other
     - createdAt: "invalid-date"


### PR DESCRIPTION
## Description

To avoid confusion, rename `Validated` to `Parsed` for parsing result. Also, use `ParseIssue` enum instead of `String` for failed parsing.

Finally, adds the `parseAndValidate()` convenience method mentioned in the README.

Closes #31

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.

---

**Note:** You can add the `auto-format` label to this pull request to enable automatic Swift formatting.
