### PR TITLE
Re-add Dynamic Property Arrays

### DIFF
--- a/Sources/JSONSchemaBuilder/Builders/JSONPropertySchemaBuilder.swift
+++ b/Sources/JSONSchemaBuilder/Builders/JSONPropertySchemaBuilder.swift
@@ -25,6 +25,12 @@ import JSONSchema
   public static func buildEither<TrueComponent, FalseComponent>(
     second component: FalseComponent
   ) -> JSONPropertyComponents.Conditional<TrueComponent, FalseComponent> { .second(component) }
+
+  public static func buildArray<Component: PropertyCollection>(
+    _ components: [Component]
+  ) -> JSONPropertyComponents.PropertyArray<Component> {
+    .init(components: components)
+  }
 }
 
 public protocol PropertyCollection: Sendable {

--- a/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyArray.swift
+++ b/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyArray.swift
@@ -1,0 +1,38 @@
+import JSONSchema
+
+extension JSONPropertyComponents {
+  public struct PropertyArray<Component: PropertyCollection>: PropertyCollection {
+    let components: [Component]
+
+    public var requiredKeys: [String] {
+      components.flatMap(\.requiredKeys)
+    }
+
+    public var schemaValue: [String: JSONValue] {
+      components.reduce(into: [:]) { result, component in
+        result.merge(component.schemaValue) { current, _ in current }
+      }
+    }
+
+    public func validate(_ dictionary: [String: JSONValue]) -> Parsed<[Component.Output], ParseIssue> {
+      var outputs: [Component.Output] = []
+      var issues: [ParseIssue] = []
+
+      for component in components {
+        let result = component.validate(dictionary)
+        switch result {
+        case .valid(let output):
+          outputs.append(output)
+        case .invalid(let issue):
+          issues.append(contentsOf: issue)
+        }
+      }
+
+      if issues.isEmpty {
+        return .valid(outputs)
+      } else {
+        return .invalid(issues)
+      }
+    }
+  }
+}

--- a/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyArray.swift
+++ b/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyArray.swift
@@ -14,7 +14,9 @@ extension JSONPropertyComponents {
       }
     }
 
-    public func validate(_ dictionary: [String: JSONValue]) -> Parsed<[Component.Output], ParseIssue> {
+    public func validate(
+      _ dictionary: [String: JSONValue]
+    ) -> Parsed<[Component.Output], ParseIssue> {
       var outputs: [Component.Output] = []
       var issues: [ParseIssue] = []
 
@@ -28,11 +30,10 @@ extension JSONPropertyComponents {
         }
       }
 
-      if issues.isEmpty {
-        return .valid(outputs)
-      } else {
+      guard issues.isEmpty else {
         return .invalid(issues)
       }
+      return .valid(outputs)
     }
   }
 }

--- a/Tests/JSONSchemaBuilderTests/JSONPropertyTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONPropertyTests.swift
@@ -88,6 +88,20 @@ struct JSONPropertySchemaTests {
     }
   }
 
+  @Test func multipleArray() throws {
+    let props = ["prop0", "prop1", "prop2", "prop3"]
+    @JSONPropertySchemaBuilder var sample: some PropertyCollection {
+      for prop in props {
+        JSONProperty(key: prop, value: JSONString())
+      }
+    }
+
+    try #require(sample.schemaValue.values.count == 4)
+    for value in sample.schemaValue.values {
+      #expect(value.object?["type"] == "string")
+    }
+  }
+
   @Test(arguments: [true, false]) func optional(_ bool: Bool) {
     @JSONPropertySchemaBuilder var sample: some PropertyCollection {
       if bool {

--- a/Tests/JSONSchemaBuilderTests/JSONSchemaTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONSchemaTests.swift
@@ -311,7 +311,7 @@ struct JSONAdvancedBuilderTests {
     #expect(sample.schemaValue == (bool ? ["type": "number", "maximum": 100] : ["type": "number"]))
   }
 
-  func array(_ bool: Bool) {
+  @Test func array() {
     let properties = ["foo", "bar", "baz"]
 
     @JSONSchemaBuilder var sample: some JSONSchemaComponent {
@@ -323,7 +323,17 @@ struct JSONAdvancedBuilderTests {
         }
       }
     }
+    print("\(sample.schemaValue)")
 
-    #expect(sample.schemaValue == (bool ? ["type": "number", "maximum": 100] : ["type": "number"]))
+    let expected: [String: JSONValue] = [
+      "type": "object",
+      "properties": [
+        "foo": ["type": "string"],
+        "bar": ["type": "string"],
+        "baz": ["type": "string"],
+      ]
+    ]
+
+    #expect(sample.schemaValue == expected)
   }
 }

--- a/Tests/JSONSchemaBuilderTests/JSONSchemaTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONSchemaTests.swift
@@ -310,4 +310,20 @@ struct JSONAdvancedBuilderTests {
 
     #expect(sample.schemaValue == (bool ? ["type": "number", "maximum": 100] : ["type": "number"]))
   }
+
+  func array(_ bool: Bool) {
+    let properties = ["foo", "bar", "baz"]
+
+    @JSONSchemaBuilder var sample: some JSONSchemaComponent {
+      JSONObject {
+        for property in properties {
+          JSONProperty(key: property) {
+            JSONString()
+          }
+        }
+      }
+    }
+
+    #expect(sample.schemaValue == (bool ? ["type": "number", "maximum": 100] : ["type": "number"]))
+  }
 }

--- a/Tests/JSONSchemaBuilderTests/JSONSchemaTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONSchemaTests.swift
@@ -331,7 +331,7 @@ struct JSONAdvancedBuilderTests {
         "foo": ["type": "string"],
         "bar": ["type": "string"],
         "baz": ["type": "string"],
-      ]
+      ],
     ]
 
     #expect(sample.schemaValue == expected)


### PR DESCRIPTION
## Description

Adds back array result builder for properties.

Closes #51 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.

---

**Note:** You can add the `auto-format` label to this pull request to enable automatic Swift formatting.
