### PR TITLE
Use Xcode 16.1

### DIFF
--- a/.github/actions/xcode-setup/action.yml
+++ b/.github/actions/xcode-setup/action.yml
@@ -6,8 +6,4 @@ runs:
     - name: Xcode setup
       shell: bash
       run: |
-        if [ -d "/Applications/Xcode_16.0.app" ]; then
-          sudo xcode-select -s /Applications/Xcode_16.0.app
-        else
-          sudo xcode-select -s /Applications/Xcode_16.1.app
-        fi
+        sudo xcode-select -s /Applications/Xcode_16.1.app

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c2c8f718710c6181e97f916c6121e06bce9745c5de2bd8e6504504bdb5808ff0",
+  "originHash" : "223fe78da1085208b4b2680d4bd76714f4e141079fbe812d7e1255de790eb698",
   "pins" : [
     {
       "identity" : "swift-docc-plugin",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c",
-        "version" : "600.0.0-prerelease-2024-06-12"
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -101,9 +101,3 @@ let package = Package(
     ,
   ]
 )
-
-for target in package.targets {
-  var settings = target.swiftSettings ?? []
-  settings.append(.enableExperimentalFeature("StrictConcurrency"))
-  target.swiftSettings = settings
-}

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0-latest"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.6"),
   ],
   targets: [
@@ -97,7 +97,10 @@ let package = Package(
         "JSONSchema",
         "JSONSchemaBuilder",
         .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
-      ])
-    ,
+      ],
+      exclude: [
+        "__Snapshots__"
+      ]
+    ),
   ]
 )


### PR DESCRIPTION
## Description

Always build with Xcode 16.1. Use released version of Swift Syntax 600.0.0 (hopefully this fixes the [SPI builds](https://swiftpackageindex.com/ajevans99/swift-json-schema/builds)). Removes redundant `StrictConcurrency` checking in `Package.swift`

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.

---

**Note:** You can add the `auto-format` label to this pull request to enable automatic Swift formatting.
