### PR TITLE
Constrain Parsed Error to Swift Error

### DIFF
--- a/Sources/JSONSchemaBuilder/Parsing/ParseIssue.swift
+++ b/Sources/JSONSchemaBuilder/Parsing/ParseIssue.swift
@@ -18,7 +18,7 @@ extension ParseIssue: CustomStringConvertible {
     case .missingRequiredProperty(let property):
       "Missing required property `\(property)`."
     case .compactMapValueNil(let value):
-      "The instance `\(value)` returned nil when evulated against compact map."
+      "The instance `\(value)` returned nil when evaluated against compact map."
     case .compositionFailure(let type, let reason, _):
       "Componsition (`\(type)`) failure: the instance \(reason)."
     }

--- a/Sources/JSONSchemaBuilder/Parsing/ParseIssue.swift
+++ b/Sources/JSONSchemaBuilder/Parsing/ParseIssue.swift
@@ -12,15 +12,15 @@ extension ParseIssue: CustomStringConvertible {
   public var description: String {
     switch self {
     case .typeMismatch(let expected, let actual):
-      "Type mismatch: the instance `\(actual)` is not of type `\(expected)`."
+      "Type mismatch: the instance of type `\(actual.primative)` does not match the expected type `\(expected)`."
     case .noEnumCaseMatch(let value):
       "The instance `\(value)` does not match any enum case."
     case .missingRequiredProperty(let property):
       "Missing required property `\(property)`."
     case .compactMapValueNil(let value):
       "The instance `\(value)` returned nil when evulated against compact map."
-    case .compositionFailure(let type, let reason, let nestedErrors):
-      "Componsition (`\(type)`) failure: the instance \(reason). \(nestedErrors.map(\.description).joined(separator: "\n"))"
+    case .compositionFailure(let type, let reason, _):
+      "Componsition (`\(type)`) failure: the instance \(reason)."
     }
   }
 }

--- a/Sources/JSONSchemaBuilder/Parsing/ParseIssue.swift
+++ b/Sources/JSONSchemaBuilder/Parsing/ParseIssue.swift
@@ -7,3 +7,20 @@ public enum ParseIssue: Error, Equatable, Sendable {
   case compactMapValueNil(value: JSONValue)
   case compositionFailure(type: JSONComposition, reason: String, nestedErrors: [ParseIssue])
 }
+
+extension ParseIssue: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .typeMismatch(let expected, let actual):
+      "Type mismatch: the instance `\(actual)` is not of type `\(expected)`."
+    case .noEnumCaseMatch(let value):
+      "The instance `\(value)` does not match any enum case."
+    case .missingRequiredProperty(let property):
+      "Missing required property `\(property)`."
+    case .compactMapValueNil(let value):
+      "The instance `\(value)` returned nil when evulated against compact map."
+    case .compositionFailure(let type, let reason, let nestedErrors):
+      "Componsition (`\(type)`) failure: the instance \(reason). \(nestedErrors.map(\.description).joined(separator: "\n"))"
+    }
+  }
+}

--- a/Sources/JSONSchemaBuilder/Parsing/ParseIssue.swift
+++ b/Sources/JSONSchemaBuilder/Parsing/ParseIssue.swift
@@ -20,7 +20,7 @@ extension ParseIssue: CustomStringConvertible {
     case .compactMapValueNil(let value):
       "The instance `\(value)` returned nil when evaluated against compact map."
     case .compositionFailure(let type, let reason, _):
-      "Componsition (`\(type)`) failure: the instance \(reason)."
+      "Composition (`\(type)`) failure: the instance \(reason)."
     }
   }
 }

--- a/Sources/JSONSchemaBuilder/Parsing/ParseIssue.swift
+++ b/Sources/JSONSchemaBuilder/Parsing/ParseIssue.swift
@@ -1,6 +1,6 @@
 import JSONSchema
 
-public enum ParseIssue: Equatable, Sendable {
+public enum ParseIssue: Error, Equatable, Sendable {
   case typeMismatch(expected: JSONType, actual: JSONValue)
   case noEnumCaseMatch(value: JSONValue)
   case missingRequiredProperty(property: String)

--- a/Sources/JSONSchemaBuilder/Parsing/Parsed.swift
+++ b/Sources/JSONSchemaBuilder/Parsing/Parsed.swift
@@ -1,6 +1,6 @@
 /// Similar to `Result` from Swift but `invalid` case has an array of errors.
 /// Adapted from [Point-Free](https://github.com/pointfreeco/swift-validated) to use variadic parameters.
-public enum Parsed<Value, Error> {
+public enum Parsed<Value, Error: Swift.Error> {
   case valid(Value)
   case invalid([Error])
 

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.4.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.4.txt
@@ -1,5 +1,5 @@
 ▿ Parsed<Poll, ParseIssue>
   ▿ invalid: 1 element
-    ▿ ParseIssue
+    ▿ Missing required property `title`.
       ▿ missingRequiredProperty: (1 element)
         - property: "title"

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.5.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.5.txt
@@ -1,20 +1,20 @@
 ▿ Parsed<Poll, ParseIssue>
   ▿ invalid: 1 element
-    ▿ ParseIssue
+    ▿ Componsition (`anyOf`) failure: the instance did not match any.
       ▿ compositionFailure: (3 elements)
         - type: JSONComposition.anyOf
         - reason: "did not match any"
         ▿ nestedErrors: 4 elements
-          ▿ ParseIssue
+          ▿ Missing required property `technology`.
             ▿ missingRequiredProperty: (1 element)
               - property: "technology"
-          ▿ ParseIssue
+          ▿ Missing required property `entertainment`.
             ▿ missingRequiredProperty: (1 element)
               - property: "entertainment"
-          ▿ ParseIssue
+          ▿ Missing required property `education`.
             ▿ missingRequiredProperty: (1 element)
               - property: "education"
-          ▿ ParseIssue
+          ▿ The instance `object(["food": JSONSchema.JSONValue.object(["_0": JSONSchema.JSONValue.object(["customDescription": JSONSchema.JSONValue.string("What\'s your favorite?")])])])` does not match any enum case.
             ▿ noEnumCaseMatch: (1 element)
               ▿ value: JSONValue
                 ▿ object: 1 key/value pair

--- a/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.5.txt
+++ b/Tests/JSONSchemaIntegrationTests/__Snapshots__/PollExampleTests/parse-instance.5.txt
@@ -1,6 +1,6 @@
 ▿ Parsed<Poll, ParseIssue>
   ▿ invalid: 1 element
-    ▿ Componsition (`anyOf`) failure: the instance did not match any.
+    ▿ Composition (`anyOf`) failure: the instance did not match any.
       ▿ compositionFailure: (3 elements)
         - type: JSONComposition.anyOf
         - reason: "did not match any"


### PR DESCRIPTION
## Description

This PR updates the Parsed<Value, Error> enum to constrain the Error generic to conform to Swift.Error. This change ensures semantic clarity, improves type safety, and enables better integration with Swift’s error-handling mechanisms.

Closes #56 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.

---

**Note:** You can add the `auto-format` label to this pull request to enable automatic Swift formatting.
