### PR TITLE
Use process instead of copy to fix simulator builds

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,3 @@ Please include a summary of the changes and the related issue. Please also inclu
 ## Additional Notes
 
 Add any other context or screenshots about the pull request here.
-
----
-
-**Note:** You can add the `auto-format` label to this pull request to enable automatic Swift formatting.

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,13 +12,22 @@ jobs:
     runs-on: macos-latest
 
     permissions:
-      contents: write
+      contents: write # Required for internal PRs to allow auto-commits
 
     name: Lint and format
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout for internal PR
+      if: ${{ github.event.pull_request.head.repo.owner.login == github.repository_owner }}
+      uses: actions/checkout@v4
       with:
+        # Use PAT which has write access
         token: ${{ secrets.PAT }}
+        ref: ${{ github.head_ref }}
+
+    - name: Checkout for external PR
+      if: ${{ github.event.pull_request.head.repo.owner.login != github.repository_owner }}
+      uses: actions/checkout@v4
+      with:
         ref: ${{ github.head_ref }}
     
     - name: Install swift-format
@@ -44,15 +53,24 @@ jobs:
           return prLabels.includes(labelToCheck);
 
     - name: Apply auto-formatting
-      if: steps.check_changes.outcome == 'failure' && steps.check_label.outputs.result == 'true'
+      if: >
+        steps.check_changes.outcome == 'failure' &&
+        steps.check_label.outputs.result == 'true' &&
+        github.event.pull_request.head.repo.owner.login == github.repository_owner
       uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: Apply auto-formatting
 
     - name: Fail if changes detected (optional)
-      if: steps.check_changes.outcome == 'failure' && steps.check_label.outputs.result == 'false'
+      if: >
+        steps.check_changes.outcome == 'failure' &&
+        (
+          github.event.pull_request.head.repo.owner.login != github.repository_owner || 
+          steps.check_label.outputs.result == 'false'
+        )
       run: |
         echo "::error::Formatting issues detected. Please fix them."
+        echo "Run 'swift-format format --in-place --parallel --recursive Sources/ Tests/' locally to fix formatting."
         exit 1
 
     - name: Lint

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
     .target(
       name: "JSONSchema",
       resources: [
-        .copy("Resources")
+        .process("Resources")
       ]
     ),
     .testTarget(

--- a/Sources/JSONSchema/Dialect.swift
+++ b/Sources/JSONSchema/Dialect.swift
@@ -110,11 +110,13 @@ public enum Dialect: String, Hashable, Sendable {
       throw MetaSchemaError.invalidBaseURI
     }
 
+    print(Bundle.module.bundlePath)
+    print(Bundle.main.bundlePath)
+
     guard
       let schemaURL = Bundle.module.url(
         forResource: "schema",
-        withExtension: "json",
-        subdirectory: "Resources/draft2020-12"
+        withExtension: "json"
       )
     else {
       throw MetaSchemaError.missingResource
@@ -122,11 +124,13 @@ public enum Dialect: String, Hashable, Sendable {
 
     let metaURLs = Bundle.module.urls(
       forResourcesWithExtension: "json",
-      subdirectory: "Resources/draft2020-12/meta"
+      subdirectory: nil
     )
     let metaDictionary: [String: JSONValue] =
       try metaURLs?
       .reduce(into: [:]) { result, url in
+        guard !url.lastPathComponent.hasPrefix("schema") else { return }
+
         #if os(Linux)
           let value = try jsonValue(from: url as URL)
           let uriString =

--- a/Sources/JSONSchema/Dialect.swift
+++ b/Sources/JSONSchema/Dialect.swift
@@ -110,9 +110,6 @@ public enum Dialect: String, Hashable, Sendable {
       throw MetaSchemaError.invalidBaseURI
     }
 
-    print(Bundle.module.bundlePath)
-    print(Bundle.main.bundlePath)
-
     guard
       let schemaURL = Bundle.module.url(
         forResource: "schema",

--- a/Sources/JSONSchema/Dialect.swift
+++ b/Sources/JSONSchema/Dialect.swift
@@ -126,13 +126,13 @@ public enum Dialect: String, Hashable, Sendable {
     let metaDictionary: [String: JSONValue] =
       try metaURLs?
       .reduce(into: [:]) { result, url in
-        guard !url.lastPathComponent.hasPrefix("schema") else { return }
-
         #if os(Linux)
+          guard url.lastPathComponent?.hasPrefix("schema") == false else { return }
           let value = try jsonValue(from: url as URL)
           let uriString =
             "meta/\(url.lastPathComponent?.replacingOccurrences(of: ".json", with: "") ?? "")"
         #else
+          guard !url.lastPathComponent.hasPrefix("schema") else { return }
           let value = try jsonValue(from: url)
           let uriString =
             "meta/\(url.lastPathComponent.replacingOccurrences(of: ".json", with: ""))"


### PR DESCRIPTION
## Description
Hey there!  When building for the iOS simulator (iphonesimulator SDK), Xcode 16+ attempts to code sign the JSONSchema resource bundle, resulting in the error:

> bundle format unrecognized, invalid, or unsuitable.

## Fix:
Change the resource declaration for the JSONSchema target from .copy("Resources") to .process("Resources").

.copy("Resources") creates a directory structure that Xcode may treat as a signable bundle for simulators (despite simulators not requiring code signing).

.process("Resources") copies files individually into the module’s resource path while preserving subdirectory structure, avoiding the creation of a monolithic bundle.

Verification:
- Tested on iOS simulator (Xcode 16.2) and physical devices.
- `swift build && swift test`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
