### PR TITLE
Fix build for Mac Catalyst

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     .iOS(.v17),
     .watchOS(.v10),
     .tvOS(.v17),
-    .macCatalyst(.v14),
+    .macCatalyst(.v17),
     .visionOS(.v1),
   ],
   products: [


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

The Mac Catalyst build version should match the iOS version instead of the macOS version. Without this change, building for Catalyst gives the following error: `The package product 'JSONSchemaMacro' requires minimum platform version 17.0 for the Mac Catalyst platform, but this target supports 14.0`
