### PR TITLE
Fix parsing of integers as doubles.

### DIFF
--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONNumber.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONNumber.swift
@@ -26,6 +26,7 @@ public struct JSONNumber: JSONNumberType {
 
   public func parse(_ value: JSONValue) -> Parsed<Double, ParseIssue> {
     if case .number(let double) = value { return .valid(double) }
+    if case .integer(let int) = value { return .valid(Double(int)) }
     return .error(.typeMismatch(expected: .number, actual: value))
   }
 }


### PR DESCRIPTION
## Description

I've found that if a schema include a `number`, intended to be parsed as a `Double` in Swift, an integer value will throw a parsing error. This PR resolves that issue.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

N/A
