### PR TITLE
Support Boolean schemas in builders

### DIFF
--- a/Sources/JSONSchemaBuilder/Builders/JSONPropertyBuilder.swift
+++ b/Sources/JSONSchemaBuilder/Builders/JSONPropertyBuilder.swift
@@ -1,5 +1,3 @@
-/// A result builder type that collects multiple ``JSONProperty`` instances into a single array.
-
 import JSONSchema
 
 /// A result builder type that collects multiple ``JSONPropertyValue`` instances into a single array.

--- a/Sources/JSONSchemaBuilder/Builders/JSONPropertySchemaBuilder.swift
+++ b/Sources/JSONSchemaBuilder/Builders/JSONPropertySchemaBuilder.swift
@@ -36,13 +36,13 @@ import JSONSchema
 public protocol PropertyCollection: Sendable {
   associatedtype Output
 
-  var schemaValue: [String: JSONValue] { get }
+  var schemaValue: SchemaValue { get }
   var requiredKeys: [String] { get }
   func validate(_ dictionary: [String: JSONValue]) -> Parsed<Output, ParseIssue>
 }
 
 public struct EmptyPropertyCollection: PropertyCollection {
-  public let schemaValue: [String: JSONValue] = [:]
+  public let schemaValue: SchemaValue = .object([:])
   public let requiredKeys: [String] = []
 
   public func validate(_ dictionary: [String: JSONValue]) -> Parsed<Void, ParseIssue> { .valid(()) }
@@ -51,8 +51,8 @@ public struct EmptyPropertyCollection: PropertyCollection {
 public struct PropertyTuple<each Property: JSONPropertyComponent>: PropertyCollection {
   let property: (repeat each Property)
 
-  public var schemaValue: [String: JSONValue] {
-    var output = [String: JSONValue]()
+  public var schemaValue: SchemaValue {
+    var output = SchemaValue.object([:])
     #if swift(>=6)
       for property in repeat each property where !property.key.isEmpty {
 
@@ -61,7 +61,7 @@ public struct PropertyTuple<each Property: JSONPropertyComponent>: PropertyColle
     #else
       func schemaForProperty<Prop: JSONPropertyComponent>(_ property: Prop) {
         guard !property.key.isEmpty else { return }
-        output[property.key] = .object(property.value.schemaValue)
+        output[property.key] = property.value.schemaValue.value
       }
       repeat schemaForProperty(each property)
     #endif

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONAnyValue.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONAnyValue.swift
@@ -2,7 +2,7 @@ import JSONSchema
 
 /// A compoment that accepts any JSON value.
 public struct JSONAnyValue: JSONSchemaComponent {
-  public var schemaValue: [KeywordIdentifier: JSONValue] = [:]
+  public var schemaValue: SchemaValue = .boolean(true)
 
   public init() {}
 

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONBooleanSchema.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONBooleanSchema.swift
@@ -1,9 +1,8 @@
 import JSONSchema
 
 public struct JSONBooleanSchema: JSONSchemaComponent {
-  // TODO: Need to change JSONSchemaComponent to support `false`/`true` schemas
-  public var schemaValue: [KeywordIdentifier: JSONValue] {
-    get { [:] }
+  public var schemaValue: SchemaValue {
+    get { .boolean(value) }
     set { fatalError("Cannot set schemaValue on JSONBooleanSchema") }
   }
 

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONComposition.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONComposition.swift
@@ -29,7 +29,7 @@ public enum JSONComposition: Sendable {
 
   /// A component that accepts any of the given schemas.
   public struct AnyOf<Output>: JSONComposableCollectionComponent {
-    public var schemaValue = [KeywordIdentifier: JSONValue]()
+    public var schemaValue = SchemaValue.object([:])
 
     public let components: [any JSONSchemaComponent<Output>]
 
@@ -38,7 +38,7 @@ public enum JSONComposition: Sendable {
       @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnyComponent<Output>]
     ) {
       components = builder()
-      schemaValue[Keywords.AnyOf.name] = .array(components.map { .object($0.schemaValue) })
+      schemaValue[Keywords.AnyOf.name] = .array(components.map(\.schemaValue.value))
     }
 
     public func parse(_ value: JSONValue) -> Parsed<Output, ParseIssue> {
@@ -58,7 +58,7 @@ public enum JSONComposition: Sendable {
 
   /// A component that requires all of the schemas to be valid.
   public struct AllOf<Output>: JSONComposableCollectionComponent {
-    public var schemaValue = [KeywordIdentifier: JSONValue]()
+    public var schemaValue = SchemaValue.object([:])
 
     public let components: [any JSONSchemaComponent<Output>]
 
@@ -67,7 +67,7 @@ public enum JSONComposition: Sendable {
       @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnyComponent<Output>]
     ) {
       components = builder()
-      schemaValue[Keywords.AllOf.name] = .array(components.map { .object($0.schemaValue) })
+      schemaValue[Keywords.AllOf.name] = .array(components.map(\.schemaValue.value))
     }
 
     public func parse(_ value: JSONValue) -> Parsed<Output, ParseIssue> {
@@ -96,7 +96,7 @@ public enum JSONComposition: Sendable {
 
   /// A component that requires exactly one of the schemas to be valid.
   public struct OneOf<Output>: JSONComposableCollectionComponent {
-    public var schemaValue = [KeywordIdentifier: JSONValue]()
+    public var schemaValue = SchemaValue.object([:])
 
     public let components: [any JSONSchemaComponent<Output>]
 
@@ -105,7 +105,7 @@ public enum JSONComposition: Sendable {
       @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnyComponent<Output>]
     ) {
       components = builder()
-      schemaValue[Keywords.OneOf.name] = .array(components.map { .object($0.schemaValue) })
+      schemaValue[Keywords.OneOf.name] = .array(components.map(\.schemaValue.value))
     }
 
     public func parse(_ value: JSONValue) -> Parsed<Output, ParseIssue> {
@@ -138,13 +138,13 @@ public enum JSONComposition: Sendable {
 
   /// A component that requires the value to not match the given schema.
   public struct Not<Component: JSONSchemaComponent>: JSONComposableComponent {
-    public var schemaValue = [KeywordIdentifier: JSONValue]()
+    public var schemaValue = SchemaValue.object([:])
 
     public let component: Component
 
     public init(@JSONSchemaBuilder _ builder: () -> Component) {
       component = builder()
-      schemaValue[Keywords.Not.name] = .object(component.schemaValue)
+      schemaValue[Keywords.Not.name] = component.schemaValue.value
     }
 
     public func parse(_ value: JSONValue) -> Parsed<JSONValue, ParseIssue> {

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchema.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchema.swift
@@ -3,7 +3,7 @@ import JSONSchema
 /// Analogous to `Group` in SwiftUI, this component can be used to group other components together.
 /// It can also be used to transform the output of the grouped components.
 public struct JSONSchema<Components: JSONSchemaComponent, NewOutput>: JSONSchemaComponent {
-  public var schemaValue: [KeywordIdentifier: JSONValue] {
+  public var schemaValue: SchemaValue {
     get { components.schemaValue }
     set { components.schemaValue = newValue }
   }

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent.swift
@@ -5,7 +5,7 @@ import JSONSchema
 public protocol JSONSchemaComponent<Output>: Sendable {
   associatedtype Output
 
-  var schemaValue: [KeywordIdentifier: JSONValue] { get set }
+  var schemaValue: SchemaValue { get set }
 
   /// Parse a JSON instance into a Swift type using the schema.
   /// - Parameter value: The value (aka instance or document) to validate.
@@ -15,12 +15,22 @@ public protocol JSONSchemaComponent<Output>: Sendable {
 
 extension JSONSchemaComponent {
   public func definition() -> Schema {
-    ObjectSchema(
-      schemaValue: schemaValue,
-      location: .init(),
-      context: .init(dialect: .draft2020_12)
-    )
-    .asSchema()
+    switch schemaValue {
+    case .boolean(let bool):
+      BooleanSchema(
+        schemaValue: bool,
+        location: .init(),
+        context: .init(dialect: .draft2020_12)
+      )
+      .asSchema()
+    case .object(let dict):
+      ObjectSchema(
+        schemaValue: dict,
+        location: .init(),
+        context: .init(dialect: .draft2020_12)
+      )
+      .asSchema()
+    }
   }
 
   public func parse(

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/AdditionalProperties.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/AdditionalProperties.swift
@@ -5,7 +5,7 @@ extension JSONComponents {
     Props: PropertyCollection,
     AdditionalProps: JSONSchemaComponent
   >: JSONSchemaComponent {
-    public var schemaValue: [KeywordIdentifier: JSONValue]
+    public var schemaValue: SchemaValue
 
     var base: JSONObject<Props>
     let additionalPropertiesSchema: AdditionalProps
@@ -14,7 +14,7 @@ extension JSONComponents {
       self.base = base
       self.additionalPropertiesSchema = additionalProperties
       schemaValue = base.schemaValue
-      schemaValue[Keywords.AdditionalProperties.name] = .object(additionalProperties.schemaValue)
+      schemaValue[Keywords.AdditionalProperties.name] = additionalProperties.schemaValue.value
     }
 
     public func parse(
@@ -29,7 +29,7 @@ extension JSONComponents {
 
       // Validate the additional properties
       var additionalProperties: [String: AdditionalProps.Output] = [:]
-      for (key, value) in dictionary where !base.schemaValue.keys.contains(key) {
+      for (key, value) in dictionary where base.schemaValue.object?.keys.contains(key) == false {
         switch additionalPropertiesSchema.parse(value) {
         case .valid(let output): additionalProperties[key] = output
         case .invalid(let errors): return .invalid(errors)

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Any.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Any.swift
@@ -8,7 +8,7 @@ extension JSONComponents {
   /// Component for type erasure.
   public struct AnyComponent<Output>: JSONSchemaComponent {
     private let validate: @Sendable (JSONValue) -> Parsed<Output, ParseIssue>
-    public var schemaValue: [KeywordIdentifier: JSONValue]
+    public var schemaValue: SchemaValue
 
     public init<Component: JSONSchemaComponent>(_ component: Component)
     where Component.Output == Output {

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/CompactMap.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/CompactMap.swift
@@ -11,7 +11,7 @@ extension JSONSchemaComponent {
 
 extension JSONComponents {
   public struct CompactMap<Upstream: JSONSchemaComponent, Output>: JSONSchemaComponent {
-    public var schemaValue: [KeywordIdentifier: JSONValue] {
+    public var schemaValue: SchemaValue {
       get { upstream.schemaValue }
       set { upstream.schemaValue = newValue }
     }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Conditional.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Conditional.swift
@@ -5,7 +5,7 @@ extension JSONComponents {
   public enum Conditional<First: JSONSchemaComponent, Second: JSONSchemaComponent>:
     JSONSchemaComponent
   where First.Output == Second.Output {
-    public var schemaValue: [KeywordIdentifier: JSONValue] {
+    public var schemaValue: SchemaValue {
       get {
         switch self {
         case .first(let first): first.schemaValue

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Enum.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Enum.swift
@@ -11,10 +11,11 @@ extension JSONSchemaComponent {
 
 extension JSONComponents {
   public struct Enum<Upstream: JSONSchemaComponent>: JSONSchemaComponent {
-    public var schemaValue: [KeywordIdentifier: JSONValue] {
+    public var schemaValue: SchemaValue {
       get {
-        upstream.schemaValue
-          .merging([Keywords.Enum.name: .array(cases)], uniquingKeysWith: { $1 })
+        var schema = upstream.schemaValue
+        schema[Keywords.Enum.name] = .array(cases)
+        return schema
       }
       set { upstream.schemaValue = newValue }
     }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/FlatMap.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/FlatMap.swift
@@ -13,7 +13,7 @@ extension JSONComponents {
   public struct FlatMap<NewSchemaComponent: JSONSchemaComponent, Upstream: JSONSchemaComponent>:
     JSONSchemaComponent
   {
-    public var schemaValue: [KeywordIdentifier: JSONValue] {
+    public var schemaValue: SchemaValue {
       get { upstream.schemaValue }
       set { upstream.schemaValue = newValue }
     }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Map.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Map.swift
@@ -11,7 +11,7 @@ extension JSONSchemaComponent {
 
 extension JSONComponents {
   public struct Map<Upstream: JSONSchemaComponent, NewOutput>: JSONSchemaComponent {
-    public var schemaValue: [KeywordIdentifier: JSONValue] {
+    public var schemaValue: SchemaValue {
       get { upstream.schemaValue }
       set { upstream.schemaValue = newValue }
     }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Optional.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Optional.swift
@@ -4,8 +4,8 @@ extension JSONComponents {
   /// A component that makes the output of the upstream component optional.
   /// When the wrapped component is nil, the output of validation is `.valid(nil)` and the schema accepts any input.
   public struct OptionalNoType<Wrapped: JSONSchemaComponent>: JSONSchemaComponent {
-    public var schemaValue: [KeywordIdentifier: JSONValue] {
-      get { wrapped?.schemaValue ?? [:] }
+    public var schemaValue: SchemaValue {
+      get { wrapped?.schemaValue ?? .boolean(true) }
       set { wrapped?.schemaValue = newValue }
     }
 

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Passthrough.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Passthrough.swift
@@ -4,7 +4,7 @@ extension JSONComponents {
   /// A compoment that performs validation on wrapped component but ignores wrapped `Output`and uses original input instead.
   /// Useful schema collections where `Output` type needs to match across schemas.
   public struct Passthrough<Component: JSONSchemaComponent>: JSONSchemaComponent {
-    public var schemaValue: [KeywordIdentifier: JSONValue] {
+    public var schemaValue: SchemaValue {
       get { wrapped.schemaValue }
       set { wrapped.schemaValue = newValue }
     }

--- a/Sources/JSONSchemaBuilder/JSONComponent/SchemaValue.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/SchemaValue.swift
@@ -1,0 +1,67 @@
+import JSONSchema
+
+public enum SchemaValue: Sendable, Equatable {
+  case boolean(Bool)
+  case object([KeywordIdentifier: JSONValue])
+
+  var object: [KeywordIdentifier: JSONValue]? {
+    switch self {
+    case .boolean: return nil
+    case .object(let dict): return dict
+    }
+  }
+
+  var value: JSONValue {
+    switch self {
+    case .boolean(let bool):
+      return .boolean(bool)
+    case .object(let dict):
+      return .object(dict)
+    }
+  }
+
+  subscript(key: KeywordIdentifier) -> JSONValue? {
+    get {
+      switch self {
+      case .boolean:
+        return nil
+      case .object(let dict):
+        return dict[key]
+      }
+    }
+    set {
+      switch self {
+      case .boolean:
+        self = .object([key: newValue!])
+      case .object(var dict):
+        dict[key] = newValue
+        self = .object(dict)
+      }
+    }
+  }
+
+  mutating func merge(_ other: SchemaValue) {
+    switch (self, other) {
+    case (.boolean, .boolean):
+      break
+    case (.boolean, .object(let dict)):
+      self = .object(dict)
+    case (.object(let dict), .boolean):
+      self = .object(dict)
+    case (.object(let dict1), .object(let dict2)):
+      self = .object(dict1.merging(dict2) { current, _ in current })
+    }
+  }
+}
+
+extension SchemaValue: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .boolean(let bool):
+      try container.encode(bool)
+    case .object(let dict):
+      try container.encode(dict)
+    }
+  }
+}

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONArray.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONArray.swift
@@ -2,7 +2,7 @@ import JSONSchema
 
 /// A JSON array type component for use in ``JSONSchemaBuilder``.
 public struct JSONArray<T: JSONSchemaComponent>: JSONSchemaComponent {
-  public var schemaValue = [KeywordIdentifier: JSONValue]()
+  public var schemaValue = SchemaValue.object([:])
 
   let items: T
 
@@ -12,8 +12,8 @@ public struct JSONArray<T: JSONSchemaComponent>: JSONSchemaComponent {
     let items = items()
     self.items = items
     schemaValue[Keywords.TypeKeyword.name] = .string(JSONType.array.rawValue)
-    if !items.schemaValue.isEmpty {
-      schemaValue[Keywords.Items.name] = .object(self.items.schemaValue)
+    if items.schemaValue.object?.isEmpty == false {
+      schemaValue[Keywords.Items.name] = self.items.schemaValue.value
     }
   }
 
@@ -52,7 +52,7 @@ extension JSONArray {
   ) -> Self {
     var copy = self
     copy.schemaValue[Keywords.PrefixItems.name] = .array(
-      prefixItems().map { .object($0.schemaValue) }
+      prefixItems().map { $0.schemaValue.value }
     )
     return copy
   }
@@ -64,7 +64,7 @@ extension JSONArray {
     @JSONSchemaBuilder _ unevaluatedItems: () -> Component
   ) -> Self {
     var copy = self
-    copy.schemaValue[Keywords.UnevaluatedItems.name] = .object(unevaluatedItems().schemaValue)
+    copy.schemaValue[Keywords.UnevaluatedItems.name] = unevaluatedItems().schemaValue.value
     return copy
   }
 
@@ -73,7 +73,7 @@ extension JSONArray {
   /// - Returns: A new `JSONArray` with the `contains` schema set.
   public func contains(@JSONSchemaBuilder _ contains: () -> any JSONSchemaComponent) -> Self {
     var copy = self
-    copy.schemaValue[Keywords.Contains.name] = .object(contains().schemaValue)
+    copy.schemaValue[Keywords.Contains.name] = contains().schemaValue.value
     return copy
   }
 

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONBoolean.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONBoolean.swift
@@ -2,9 +2,9 @@ import JSONSchema
 
 /// A JSON boolean schema component for use in ``JSONSchemaBuilder``.
 public struct JSONBoolean: JSONSchemaComponent {
-  public var schemaValue: [KeywordIdentifier: JSONValue] = [
+  public var schemaValue: SchemaValue = .object([
     Keywords.TypeKeyword.name: .string(JSONType.boolean.rawValue)
-  ]
+  ])
 
   public init() {}
 

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONNull.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONNull.swift
@@ -2,9 +2,9 @@ import JSONSchema
 
 /// A JSON null schema component for use in ``JSONSchemaBuilder``.
 public struct JSONNull: JSONSchemaComponent {
-  public var schemaValue: [KeywordIdentifier: JSONValue] = [
+  public var schemaValue: SchemaValue = .object([
     Keywords.TypeKeyword.name: .string(JSONType.null.rawValue)
-  ]
+  ])
 
   public init() {}
 

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONNumber.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONNumber.swift
@@ -4,7 +4,7 @@ public protocol JSONNumberType: JSONSchemaComponent {}
 
 /// A JSON integer schema component for use in ``JSONSchemaBuilder``.
 public struct JSONInteger: JSONNumberType {
-  public var schemaValue = [KeywordIdentifier: JSONValue]()
+  public var schemaValue = SchemaValue.object([:])
 
   public init() {
     schemaValue[Keywords.TypeKeyword.name] = .string(JSONType.integer.rawValue)
@@ -18,7 +18,7 @@ public struct JSONInteger: JSONNumberType {
 
 /// A JSON number schema component for use in ``JSONSchemaBuilder``.
 public struct JSONNumber: JSONNumberType {
-  public var schemaValue = [KeywordIdentifier: JSONValue]()
+  public var schemaValue = SchemaValue.object([:])
 
   public init() {
     schemaValue[Keywords.TypeKeyword.name] = .string(JSONType.number.rawValue)

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONObject.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONObject.swift
@@ -2,7 +2,7 @@ import JSONSchema
 
 /// A JSON object schema component for use in ``JSONSchemaBuilder``.
 public struct JSONObject<Props: PropertyCollection>: JSONSchemaComponent {
-  public var schemaValue = [KeywordIdentifier: JSONValue]()
+  public var schemaValue = SchemaValue.object([:])
 
   let properties: Props
 
@@ -23,8 +23,8 @@ public struct JSONObject<Props: PropertyCollection>: JSONSchemaComponent {
     if !properties.requiredKeys.isEmpty {
       schemaValue[Keywords.Required.name] = .array(properties.requiredKeys.map { .string($0) })
     }
-    if !properties.schemaValue.isEmpty {
-      schemaValue[Keywords.Properties.name] = .object(properties.schemaValue)
+    if properties.schemaValue.object?.isEmpty == false {
+      schemaValue[Keywords.Properties.name] = properties.schemaValue.value
     }
   }
 
@@ -45,7 +45,7 @@ extension JSONObject {
     @JSONPropertySchemaBuilder _ patternProperties: () -> Pattern
   ) -> Self {
     var copy = self
-    copy.schemaValue[Keywords.PatternProperties.name] = .object(patternProperties().schemaValue)
+    copy.schemaValue[Keywords.PatternProperties.name] = patternProperties().schemaValue.value
     return copy
   }
 
@@ -81,7 +81,7 @@ extension JSONObject {
     @JSONSchemaBuilder _ content: () -> C
   ) -> Self {
     var copy = self
-    copy.schemaValue[Keywords.UnevaluatedProperties.name] = .object(content().schemaValue)
+    copy.schemaValue[Keywords.UnevaluatedProperties.name] = content().schemaValue.value
     return copy
   }
 
@@ -93,7 +93,7 @@ extension JSONObject {
     @JSONSchemaBuilder _ content: () -> C
   ) -> Self {
     var copy = self
-    copy.schemaValue[Keywords.PropertyNames.name] = .object(content().schemaValue)
+    copy.schemaValue[Keywords.PropertyNames.name] = content().schemaValue.value
     return copy
   }
 

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONString.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONString.swift
@@ -2,7 +2,7 @@ import JSONSchema
 
 /// A JSON string schema component for use in ``JSONSchemaBuilder``.
 public struct JSONString: JSONSchemaComponent {
-  public var schemaValue = [KeywordIdentifier: JSONValue]()
+  public var schemaValue = SchemaValue.object([:])
 
   public init() {
     schemaValue[Keywords.TypeKeyword.name] = .string(JSONType.string.rawValue)

--- a/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyArray.swift
+++ b/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyArray.swift
@@ -8,9 +8,9 @@ extension JSONPropertyComponents {
       components.flatMap(\.requiredKeys)
     }
 
-    public var schemaValue: [String: JSONValue] {
-      components.reduce(into: [:]) { result, component in
-        result.merge(component.schemaValue) { current, _ in current }
+    public var schemaValue: SchemaValue {
+      components.reduce(into: SchemaValue.object([:])) { result, component in
+        result.merge(component.schemaValue)
       }
     }
 

--- a/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyConditional.swift
+++ b/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyConditional.swift
@@ -4,7 +4,7 @@ extension JSONPropertyComponents {
   /// A component that conditionally applies one of two property collections.
   public enum Conditional<First: PropertyCollection, Second: PropertyCollection>: PropertyCollection
   where First.Output == Second.Output {
-    public var schemaValue: [String: JSONValue] {
+    public var schemaValue: SchemaValue {
       switch self {
       case .first(let first): first.schemaValue
       case .second(let second): second.schemaValue

--- a/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyOptional.swift
+++ b/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyOptional.swift
@@ -3,7 +3,7 @@ import JSONSchema
 extension JSONPropertyComponents {
   /// A property collection that wraps another property collection and makes it's validation result optional.
   public struct OptionalNoType<Wrapped: PropertyCollection>: PropertyCollection {
-    public var schemaValue: [String: JSONValue] { wrapped?.schemaValue ?? [:] }
+    public var schemaValue: SchemaValue { wrapped?.schemaValue ?? .object([:]) }
 
     public var requiredKeys: [String] { wrapped?.requiredKeys ?? [] }
 

--- a/Tests/JSONSchemaBuilderTests/DocumentationExampleTests.swift
+++ b/Tests/JSONSchemaBuilderTests/DocumentationExampleTests.swift
@@ -44,7 +44,7 @@ struct DocumentationExampleTests {
       ],
     ]
 
-    #expect(jsonSchema.schemaValue == expected)
+    #expect(jsonSchema.schemaValue == .object(expected))
   }
 
   @Schemable struct Person {
@@ -136,6 +136,6 @@ struct DocumentationExampleTests {
 
   @Test func readMeEnumMacro() {
     let expected: [String: JSONValue] = ["type": "string", "enum": ["active", "inactive"]]
-    #expect(Status.schema.schemaValue == expected)
+    #expect(Status.schema.schemaValue == .object(expected))
   }
 }

--- a/Tests/JSONSchemaBuilderTests/JSONCompositionTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONCompositionTests.swift
@@ -19,7 +19,7 @@ struct JSONCompositionTests {
       ]
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 
   @Test func allOfComposition() {
@@ -37,7 +37,7 @@ struct JSONCompositionTests {
       ]
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 
   @Test func oneOfComposition() {
@@ -55,7 +55,7 @@ struct JSONCompositionTests {
       ]
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 
   @Test func notComposition() {
@@ -67,7 +67,7 @@ struct JSONCompositionTests {
       "not": ["type": "string"]
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 
   @Test func annotations() {
@@ -89,6 +89,6 @@ struct JSONCompositionTests {
       ],
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 }

--- a/Tests/JSONSchemaBuilderTests/JSONEnumTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONEnumTests.swift
@@ -15,7 +15,7 @@ struct JSONEnumTests {
       "enum": ["red"],
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 
   @Test func sameType() {
@@ -33,7 +33,7 @@ struct JSONEnumTests {
       "enum": ["red", "amber", "green"],
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 
   @Test func differentType() {
@@ -52,7 +52,7 @@ struct JSONEnumTests {
       "enum": ["red", "amber", "green", nil, 42]
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 
   @Test func annotations() {
@@ -72,6 +72,6 @@ struct JSONEnumTests {
       "enum": ["red", "amber", "green"],
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 }

--- a/Tests/JSONSchemaBuilderTests/JSONPropertyTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONPropertyTests.swift
@@ -82,8 +82,8 @@ struct JSONPropertySchemaTests {
       JSONProperty(key: "prop3", value: JSONString())
     }
 
-    try #require(sample.schemaValue.values.count == 4)
-    for value in sample.schemaValue.values {
+    try #require(sample.schemaValue.object?.values.count == 4)
+    for value in sample.schemaValue.object!.values {
       #expect(value.object?["type"] == "string")
     }
   }
@@ -96,8 +96,8 @@ struct JSONPropertySchemaTests {
       }
     }
 
-    try #require(sample.schemaValue.values.count == 4)
-    for value in sample.schemaValue.values {
+    try #require(sample.schemaValue.object?.values.count == 4)
+    for value in sample.schemaValue.object!.values {
       #expect(value.object?["type"] == "string")
     }
   }
@@ -109,7 +109,7 @@ struct JSONPropertySchemaTests {
       }
     }
 
-    #expect(sample.schemaValue.count == (bool ? 1 : 0))
+    #expect(sample.schemaValue.object?.count == (bool ? 1 : 0))
   }
 
   @Test(arguments: [true, false]) func either(_ bool: Bool) throws {
@@ -121,7 +121,7 @@ struct JSONPropertySchemaTests {
       }
     }
 
-    let firstProperty = try #require(sample.schemaValue.first)
+    let firstProperty = try #require(sample.schemaValue.object?.first)
     #expect(firstProperty.key == (bool ? "prop0" : "prop1"))
   }
 }

--- a/Tests/JSONSchemaBuilderTests/JSONSchemaTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONSchemaTests.swift
@@ -53,10 +53,10 @@ struct JSONSchemaOptionBuilderTests {
         "type": "string",
         "pattern": "^property[0-9]$",
       ],
-      "unevaluatedProperties": [:],  // TODO: Should be false
+      "unevaluatedProperties": false,
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 
   @Test func objectOptionsProperty() throws {
@@ -79,10 +79,7 @@ struct JSONSchemaOptionBuilderTests {
       ],
     ]
 
-    #expect(
-      sample.schemaValue
-        == expected
-    )
+    #expect(sample.schemaValue == .object(expected))
   }
 
   @Test func supplementalObjectOptions() throws {
@@ -94,13 +91,13 @@ struct JSONSchemaOptionBuilderTests {
 
     let expected: [String: JSONValue] = [
       "type": "object",
-      "additionalProperties": [:],  // TODO: Should be false
+      "additionalProperties": false,
       "unevaluatedProperties": [
         "type": "integer"
       ],
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 
   @Test func stringOptions() throws {
@@ -120,7 +117,7 @@ struct JSONSchemaOptionBuilderTests {
       "format": "uuid",
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 
   @Test func numberOptions() throws {
@@ -138,7 +135,7 @@ struct JSONSchemaOptionBuilderTests {
       "exclusiveMaximum": 100,
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 
   @Test func supplementalNumberOptions() throws {
@@ -156,7 +153,7 @@ struct JSONSchemaOptionBuilderTests {
       "maximum": 5000,
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 
   @Test func arrayOptions() throws {
@@ -172,7 +169,7 @@ struct JSONSchemaOptionBuilderTests {
       ],
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 
   @Test func supplementalArrayOptions() throws {
@@ -202,7 +199,7 @@ struct JSONSchemaOptionBuilderTests {
         ["type": "boolean"],
         ["type": "integer"],
       ],
-      "unevaluatedItems": [:],  // TODO: Should be false
+      "unevaluatedItems": false,
       "contains": [
         "type": "number"
       ],
@@ -213,7 +210,7 @@ struct JSONSchemaOptionBuilderTests {
       "uniqueItems": true,
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 }
 
@@ -249,7 +246,7 @@ struct JSONSchemaAnnotationsBuilderTests {
       "$comment": "Comment",
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 
   @Test func nonValueBuilderAnnotations() throws {
@@ -265,7 +262,7 @@ struct JSONSchemaAnnotationsBuilderTests {
       "examples": ["1", nil, false, [1, 2, 3], ["hello": "world"]],
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 
   @Test func description() {
@@ -288,7 +285,7 @@ struct JSONSchemaAnnotationsBuilderTests {
       "description": "A product from Acme's catalog",
     ]
 
-    #expect(sample.schemaValue == expected)
+    #expect(sample.schemaValue == .object(expected))
   }
 }
 
@@ -300,7 +297,7 @@ struct JSONAdvancedBuilderTests {
       }
     }
 
-    #expect(sample.schemaValue == (bool ? ["type": "string"] : [:]))
+    #expect(sample.schemaValue == (bool ? .object(["type": "string"]) : .boolean(true)))
   }
 
   @Test(arguments: [true, false]) func either(_ bool: Bool) {
@@ -308,7 +305,7 @@ struct JSONAdvancedBuilderTests {
       if bool { JSONNumber().maximum(100) } else { JSONNumber() }
     }
 
-    #expect(sample.schemaValue == (bool ? ["type": "number", "maximum": 100] : ["type": "number"]))
+    #expect(sample.schemaValue == .object((bool ? ["type": "number", "maximum": 100] : ["type": "number"])))
   }
 
   @Test func array() {
@@ -323,7 +320,6 @@ struct JSONAdvancedBuilderTests {
         }
       }
     }
-    print("\(sample.schemaValue)")
 
     let expected: [String: JSONValue] = [
       "type": "object",
@@ -334,6 +330,5 @@ struct JSONAdvancedBuilderTests {
       ],
     ]
 
-    #expect(sample.schemaValue == expected)
-  }
+    #expect(sample.schemaValue == .object(expected))  }
 }


### PR DESCRIPTION
## Description

This PR adds support for Boolean schemas in builders by introducing a new `SchemaValue` enum and using it over dictionaries. 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.
