### PR TITLE
Fixed swift-syntax dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
-    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.1"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.6"),
   ],
   targets: [

--- a/Sources/JSONSchemaMacro/Schemable/SchemaGenerator.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SchemaGenerator.swift
@@ -2,13 +2,13 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 
 struct EnumSchemaGenerator {
-  let declModifer: DeclModifierSyntax?
+  let declModifier: DeclModifierSyntax?
   let name: TokenSyntax
   let members: MemberBlockItemListSyntax
   let attributes: AttributeListSyntax
 
   init(fromEnum enumDecl: EnumDeclSyntax) {
-    declModifer = enumDecl.modifiers.first
+    declModifier = enumDecl.modifiers.first
     name = enumDecl.name.trimmed
     members = enumDecl.memberBlock.members
     attributes = enumDecl.attributes
@@ -46,7 +46,7 @@ struct EnumSchemaGenerator {
     }
 
     let variableDecl: DeclSyntax = """
-      \(declModifer)static var schema: some JSONSchemaComponent<\(name)> {
+      \(declModifier)static var schema: some JSONSchemaComponent<\(name)> {
         \(codeBlockItem)
       }
       """
@@ -87,20 +87,20 @@ struct EnumSchemaGenerator {
 }
 
 struct SchemaGenerator {
-  let declModifer: DeclModifierSyntax?
+  let declModifier: DeclModifierSyntax?
   let name: TokenSyntax
   let members: MemberBlockItemListSyntax
   let attributes: AttributeListSyntax
 
   init(fromClass classDecl: ClassDeclSyntax) {
-    declModifer = classDecl.modifiers.first
+    declModifier = classDecl.modifiers.first
     name = classDecl.name.trimmed
     members = classDecl.memberBlock.members
     attributes = classDecl.attributes
   }
 
   init(fromStruct structDecl: StructDeclSyntax) {
-    declModifer = structDecl.modifiers.first
+    declModifier = structDecl.modifiers.first
     name = structDecl.name.trimmed
     members = structDecl.memberBlock.members
     attributes = structDecl.attributes
@@ -131,7 +131,7 @@ struct SchemaGenerator {
     }
 
     let variableDecl: DeclSyntax = """
-      \(declModifer)static var schema: some JSONSchemaComponent<\(name)> {
+      \(declModifier)static var schema: some JSONSchemaComponent<\(name)> {
         JSONSchema(\(name).init) { \(codeBlockItem) }
       }
       """


### PR DESCRIPTION
## Description
- Fixed typo (declModifer => declModifier)
- Fixed swift-syntax dependency
   - Current implementation utilizes `TypeSyntaxEnum`, which only introduced from [SwiftSyntax 600.0.1](https://github.com/swiftlang/swift-syntax/releases/tag/600.0.1)
   - Yet previously it allowed resolving to version previous to 600.0.1
 
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes
