### PR TITLE
Use docstrings as description on macro expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,15 @@ Use the `@Schemable` macro from `JSONSchemaBuilder` to automatically generate th
 @ObjectOptions(.additionalProperties { false })
 struct Person {
   let firstName: String
+
   let lastName: String?
+
   @NumberOptions(.minimum(0), .maximum(120))
   let age: Int
+
+  /// A short bio or summary about the person, shown on their public profile.
+  @StringOptions(.maxLength(500))
+  let bio: String?
 }
 ```
 
@@ -102,28 +108,46 @@ struct Person {
   ```swift
   struct Person {
     let firstName: String
+
     let lastName: String?
+
     let age: Int
+
+    /// A short bio or summary about the person, shown on their public profile.
+    let bio: String?
 
     // Auto-generated schema ↴
     static var schema: some JSONSchemaComponent<Person> {
       JSONSchema(Person.init) {
-        JSONObject {
-          JSONProperty(key: "firstName") {
-            JSONString()
+          JSONObject {
+              JSONProperty(key: "firstName") {
+                  JSONString()
+              }
+              .required()
+              JSONProperty(key: "lastName") {
+                  JSONString()
+              }
+              JSONProperty(key: "age") {
+                  JSONInteger()
+                  .minimum(0)
+                  .maximum(120)
+              }
+              .required()
+              JSONProperty(key: "bio") {
+                  JSONString()
+                  .maxLength(500)
+                  .description(#"""
+                  A short bio or summary about the person, shown on their public profile.
+                  """#)
+              }
           }
-          .required()
-          JSONProperty(key: "lastName") {
-            JSONString()
+          .additionalProperties {
+              false
           }
-          JSONProperty(key: "age") {
-            JSONInteger()
-            .minimum(0)
-            .maximum(120)
+          // Drop the parse information. Use custom builder if needed.
+          .map {
+              $0.0
           }
-          .required()
-        }
-        .additionalProperties { false }
       }
     }
   }

--- a/Sources/JSONSchemaMacro/Schemable/SchemableMember.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SchemableMember.swift
@@ -111,7 +111,7 @@ struct SchemableMember {
     guard let annotationArguments = annotationArguments else { return false }
     return annotationArguments.contains { argument in
       guard let functionCall = argument.expression.as(FunctionCallExprSyntax.self),
-            let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self)
+        let memberAccess = functionCall.calledExpression.as(MemberAccessExprSyntax.self)
       else { return false }
       return memberAccess.declName.baseName.text == "description"
     }

--- a/Sources/JSONSchemaMacro/Schemable/SwiftSyntaxExtensions.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SwiftSyntaxExtensions.swift
@@ -119,6 +119,40 @@ extension VariableDeclSyntax {
     }
     .contains(where: { $0 == "ExcludeFromSchema" })
   }
+  
+  var docString: String? {
+    // Get the leading trivia which contains the docstring
+    let trivia = leadingTrivia
+    var docStringLines: [String] = []
+    
+    for piece in trivia {
+      switch piece {
+      case .docLineComment(let comment):
+        // Remove the /// prefix and trim whitespace
+        let line = String(comment.dropFirst(3)).trimmingCharacters(in: .whitespaces)
+        docStringLines.append(line)
+      case .docBlockComment(let comment):
+        // Remove the /** and */ and trim whitespace
+        let content = comment.dropFirst(3).dropLast(2)
+        let lines = content.split(separator: "\n")
+        for line in lines {
+          // Remove leading asterisks and trim whitespace
+          let trimmed = line.trimmingCharacters(in: .whitespaces)
+          if !trimmed.isEmpty {
+            // Remove leading asterisk and any following whitespace
+            let cleanLine = trimmed.hasPrefix("*") ? 
+              String(trimmed.dropFirst().trimmingCharacters(in: .whitespaces)) : 
+              trimmed
+            docStringLines.append(cleanLine)
+          }
+        }
+      default:
+        break
+      }
+    }
+    
+    return docStringLines.isEmpty ? nil : docStringLines.joined(separator: "\n")
+  }
 }
 
 extension MemberBlockItemListSyntax {

--- a/Sources/JSONSchemaMacro/Schemable/SwiftSyntaxExtensions.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SwiftSyntaxExtensions.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftSyntax
 
 extension TypeSyntax {

--- a/Sources/JSONSchemaMacro/Schemable/SwiftSyntaxExtensions.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SwiftSyntaxExtensions.swift
@@ -119,12 +119,12 @@ extension VariableDeclSyntax {
     }
     .contains(where: { $0 == "ExcludeFromSchema" })
   }
-  
+
   var docString: String? {
     // Get the leading trivia which contains the docstring
     let trivia = leadingTrivia
     var docStringLines: [String] = []
-    
+
     for piece in trivia {
       switch piece {
       case .docLineComment(let comment):
@@ -140,9 +140,9 @@ extension VariableDeclSyntax {
           let trimmed = line.trimmingCharacters(in: .whitespaces)
           if !trimmed.isEmpty {
             // Remove leading asterisk and any following whitespace
-            let cleanLine = trimmed.hasPrefix("*") ? 
-              String(trimmed.dropFirst().trimmingCharacters(in: .whitespaces)) : 
-              trimmed
+            let cleanLine =
+              trimmed.hasPrefix("*")
+              ? String(trimmed.dropFirst().trimmingCharacters(in: .whitespaces)) : trimmed
             docStringLines.append(cleanLine)
           }
         }
@@ -150,7 +150,7 @@ extension VariableDeclSyntax {
         break
       }
     }
-    
+
     return docStringLines.isEmpty ? nil : docStringLines.joined(separator: "\n")
   }
 }

--- a/Tests/JSONSchemaBuilderTests/DocumentationExampleTests.swift
+++ b/Tests/JSONSchemaBuilderTests/DocumentationExampleTests.swift
@@ -51,9 +51,15 @@ struct DocumentationExampleTests {
   @ObjectOptions(.additionalProperties { false })
   struct Person {
     let firstName: String
+
     let lastName: String?
+
     @NumberOptions(.minimum(0), .maximum(120))
     let age: Int
+
+    /// A short bio or summary about the person, shown on their public profile.
+    @StringOptions(.maxLength(500))
+    let bio: String?
   }
 
   @Test func readMeMacros() {

--- a/Tests/JSONSchemaMacroTests/SchemableExpansionTests.swift
+++ b/Tests/JSONSchemaMacroTests/SchemableExpansionTests.swift
@@ -390,4 +390,282 @@ struct SchemableExpansionTests {
       macros: testMacros
     )
   }
+
+  @Test func docstringSupport() {
+    assertMacroExpansion(
+      """
+      @Schemable
+      struct Weather {
+        /// The current temperature in fahrenheit
+        let temperature: Double
+        
+        /// The city name where the weather is being reported
+        let location: String
+        
+        /// Whether it is currently raining
+        let isRaining: Bool
+        
+        /// The wind speed in miles per hour
+        let windSpeed: Int
+        
+        /// The amount of precipitation in inches
+        let precipitationAmount: Double?
+        
+        /// The relative humidity as a percentage
+        let humidity: Float
+      }
+      """,
+      expandedSource: """
+        struct Weather {
+          /// The current temperature in fahrenheit
+          let temperature: Double
+          
+          /// The city name where the weather is being reported
+          let location: String
+          
+          /// Whether it is currently raining
+          let isRaining: Bool
+          
+          /// The wind speed in miles per hour
+          let windSpeed: Int
+          
+          /// The amount of precipitation in inches
+          let precipitationAmount: Double?
+          
+          /// The relative humidity as a percentage
+          let humidity: Float
+
+          static var schema: some JSONSchemaComponent<Weather> {
+            JSONSchema(Weather.init) {
+              JSONObject {
+                JSONProperty(key: "temperature") {
+                  JSONNumber()
+                  .description(#\"\"\"
+                  The current temperature in fahrenheit
+                  \"\"\"#)
+                }
+                .required()
+                JSONProperty(key: "location") {
+                  JSONString()
+                  .description(#\"\"\"
+                  The city name where the weather is being reported
+                  \"\"\"#)
+                }
+                .required()
+                JSONProperty(key: "isRaining") {
+                  JSONBoolean()
+                  .description(#\"\"\"
+                  Whether it is currently raining
+                  \"\"\"#)
+                }
+                .required()
+                JSONProperty(key: "windSpeed") {
+                  JSONInteger()
+                  .description(#\"\"\"
+                  The wind speed in miles per hour
+                  \"\"\"#)
+                }
+                .required()
+                JSONProperty(key: "precipitationAmount") {
+                  JSONNumber()
+                  .description(#\"\"\"
+                  The amount of precipitation in inches
+                  \"\"\"#)
+                }
+                JSONProperty(key: "humidity") {
+                  JSONNumber()
+                  .description(#\"\"\"
+                  The relative humidity as a percentage
+                  \"\"\"#)
+                }
+                .required()
+              }
+            }
+          }
+        }
+
+        extension Weather: Schemable {
+        }
+        """,
+      macros: testMacros
+    )
+  }
+
+  @Test func docstringWithSchemaOptions() {
+    assertMacroExpansion(
+      """
+      @Schemable
+      struct Weather {
+        /// The current temperature in fahrenheit
+        @SchemaOptions(.description("Temperature in degrees Fahrenheit"))
+        let temperature: Double
+        
+        /// The city name where the weather is being reported
+        let location: String
+      }
+      """,
+      expandedSource: """
+        struct Weather {
+          /// The current temperature in fahrenheit
+          @SchemaOptions(.description("Temperature in degrees Fahrenheit"))
+          let temperature: Double
+          
+          /// The city name where the weather is being reported
+          let location: String
+
+          static var schema: some JSONSchemaComponent<Weather> {
+            JSONSchema(Weather.init) {
+              JSONObject {
+                JSONProperty(key: "temperature") {
+                  JSONNumber()
+                  .description("Temperature in degrees Fahrenheit")
+                }
+                .required()
+                JSONProperty(key: "location") {
+                  JSONString()
+                  .description(#\"\"\"
+                  The city name where the weather is being reported
+                  \"\"\"#)
+                }
+                .required()
+              }
+            }
+          }
+        }
+
+        extension Weather: Schemable {
+        }
+        """,
+      macros: testMacros
+    )
+  }
+
+  @Test func blockDocstringSupport() {
+    assertMacroExpansion(
+      """
+      @Schemable
+      struct Weather {
+        /**
+         * The current temperature in fahrenheit.
+         * This value should be between -100 and 150.
+         */
+        let temperature: Double
+        
+        /**
+         * The city name where the weather is being reported.
+         * Must be a valid city name.
+         */
+        let location: String
+      }
+      """,
+      expandedSource: """
+        struct Weather {
+          /**
+           * The current temperature in fahrenheit.
+           * This value should be between -100 and 150.
+           */
+          let temperature: Double
+          
+          /**
+           * The city name where the weather is being reported.
+           * Must be a valid city name.
+           */
+          let location: String
+
+          static var schema: some JSONSchemaComponent<Weather> {
+            JSONSchema(Weather.init) {
+              JSONObject {
+                JSONProperty(key: "temperature") {
+                  JSONNumber()
+                  .description(#\"\"\"
+                  The current temperature in fahrenheit.
+                  This value should be between -100 and 150.
+                  \"\"\"#)
+                }
+                .required()
+                JSONProperty(key: "location") {
+                  JSONString()
+                  .description(#\"\"\"
+                  The city name where the weather is being reported.
+                  Must be a valid city name.
+                  \"\"\"#)
+                }
+                .required()
+              }
+            }
+          }
+        }
+
+        extension Weather: Schemable {
+        }
+        """,
+      macros: testMacros
+    )
+  }
+
+  @Test func complexDocstringSupport() {
+    assertMacroExpansion(
+      """
+      @Schemable
+      struct ComplexDocstring {
+        /// This is a complex docstring with **bold** and *italic* text.
+        /// It spans multiple lines and includes:
+        /// - Bullet points
+        /// - More bullet points
+        /// 
+        /// It also has a code block:
+        /// ```swift
+        /// let example = "code"
+        /// ```
+        /// 
+        /// And some `inline code` as well.
+        let complexProperty: String
+      }
+      """,
+      expandedSource: #"""
+        struct ComplexDocstring {
+          /// This is a complex docstring with **bold** and *italic* text.
+          /// It spans multiple lines and includes:
+          /// - Bullet points
+          /// - More bullet points
+          /// 
+          /// It also has a code block:
+          /// ```swift
+          /// let example = "code"
+          /// ```
+          /// 
+          /// And some `inline code` as well.
+          let complexProperty: String
+
+          static var schema: some JSONSchemaComponent<ComplexDocstring> {
+            JSONSchema(ComplexDocstring.init) {
+              JSONObject {
+                JSONProperty(key: "complexProperty") {
+                  JSONString()
+                    .description(#\"\"\"
+                    This is a complex docstring with **bold** and *italic* text.
+                    It spans multiple lines and includes:
+                    - Bullet points
+                    - More bullet points
+                    
+                    It also has a code block:
+                    ```swift
+                    let example = "code"
+                    ```
+                    
+                    And some `inline code` as well.
+                    \"\"\"#)
+                }
+                .required()
+              }
+            }
+          }
+        }
+
+        extension ComplexDocstring: Schemable {
+        }
+        """#,
+      macros: testMacros
+    )
+  }
 }

--- a/Tests/JSONSchemaMacroTests/SchemableExpansionTests.swift
+++ b/Tests/JSONSchemaMacroTests/SchemableExpansionTests.swift
@@ -622,7 +622,7 @@ struct SchemableExpansionTests {
         let complexProperty: String
       }
       """,
-      expandedSource: #"""
+      expandedSource: """
         struct ComplexDocstring {
           /// This is a complex docstring with **bold** and *italic* text.
           /// It spans multiple lines and includes:
@@ -642,19 +642,17 @@ struct SchemableExpansionTests {
               JSONObject {
                 JSONProperty(key: "complexProperty") {
                   JSONString()
-                    .description(#\"\"\"
-                    This is a complex docstring with **bold** and *italic* text.
-                    It spans multiple lines and includes:
-                    - Bullet points
-                    - More bullet points
-                    
-                    It also has a code block:
-                    ```swift
-                    let example = "code"
-                    ```
-                    
-                    And some `inline code` as well.
-                    \"\"\"#)
+                  .description(#\"\"\"
+                  This is a complex docstring with **bold** and *italic* text.
+                  It spans multiple lines and includes:
+                  - Bullet points
+                  - More bullet points\n
+                  It also has a code block:
+                  ```swift
+                  let example = "code"
+                  ```\n
+                  And some `inline code` as well.
+                  \"\"\"#)
                 }
                 .required()
               }
@@ -664,7 +662,7 @@ struct SchemableExpansionTests {
 
         extension ComplexDocstring: Schemable {
         }
-        """#,
+        """,
       macros: testMacros
     )
   }

--- a/Tests/JSONSchemaTests/JSONSchemaTestSuite.swift
+++ b/Tests/JSONSchemaTests/JSONSchemaTestSuite.swift
@@ -47,11 +47,9 @@ struct JSONSchemaTestSuite {
       return
     }
 
-    let schema = try #require(
-      try Schema(
-        rawSchema: schemaTest.schema,
-        context: .init(dialect: .draft2020_12, remoteSchema: Self.remotes)
-      )
+    let schema = try Schema(
+      rawSchema: schemaTest.schema,
+      context: .init(dialect: .draft2020_12, remoteSchema: Self.remotes)
     )
 
     for testCase in schemaTest.tests {


### PR DESCRIPTION
## Description

This pull request enhances the `Schemable` macro to support extracting and utilizing docstrings for schema descriptions. It introduces functionality to parse docstrings from Swift code and integrate them into the generated JSON schema.

For example:

```swift
@Schemable
@ObjectOptions(.additionalProperties { false })
struct Package {
  let id: String

  @StringOptions(.pattern(#"^[A-Z]{2}\d{9}[A-Z]{2}$"#))
  let trackingNumber: String

  /// The name of the shipping carrier (e.g. "FedEx", "UPS", "DHL").
  /// Required for generating tracking links and logistics integration.
  @StringOptions(.maxLength(100))
  let carrier: String

  @NumberOptions(.minimum(0))
  let weightInKg: Double?

  let isDelivered: Bool
}
```

will now expand the `carrier` property to include the docstring as the description in the generated JSON schema:

```swift
        JSONProperty(key: "carrier") {
          JSONString()
          .maxLength(100)
          .description(#"""
          The name of the shipping carrier (e.g. "FedEx", "UPS", "DHL").
          Required for generating tracking links and logistics integration.
          """#)
        }
        .required()
```

Closes #48 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.
