### PR TITLE
Make some SchemaValue props public

### DIFF
--- a/Sources/JSONSchemaBuilder/JSONComponent/SchemaValue.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/SchemaValue.swift
@@ -4,14 +4,14 @@ public enum SchemaValue: Sendable, Equatable {
   case boolean(Bool)
   case object([KeywordIdentifier: JSONValue])
 
-  var object: [KeywordIdentifier: JSONValue]? {
+  public var object: [KeywordIdentifier: JSONValue]? {
     switch self {
     case .boolean: return nil
     case .object(let dict): return dict
     }
   }
 
-  var value: JSONValue {
+  public var value: JSONValue {
     switch self {
     case .boolean(let bool):
       return .boolean(bool)
@@ -20,7 +20,7 @@ public enum SchemaValue: Sendable, Equatable {
     }
   }
 
-  subscript(key: KeywordIdentifier) -> JSONValue? {
+  public subscript(key: KeywordIdentifier) -> JSONValue? {
     get {
       switch self {
       case .boolean:
@@ -40,7 +40,7 @@ public enum SchemaValue: Sendable, Equatable {
     }
   }
 
-  mutating func merge(_ other: SchemaValue) {
+  public mutating func merge(_ other: SchemaValue) {
     switch (self, other) {
     case (.boolean, .boolean):
       break


### PR DESCRIPTION
## Description

This pull request updates the `SchemaValue` enum in the `Sources/JSONSchemaBuilder/JSONComponent/SchemaValue.swift` file to make certain properties and methods publicly accessible. These changes enhance the usability of the `SchemaValue` enum by allowing external modules to access and modify its members.

### Accessibility Updates:

* Made the `object` property publicly accessible to allow external modules to retrieve the dictionary representation of a `.object` case.
* Made the `value` property publicly accessible to enable external modules to retrieve the `JSONValue` representation of a `SchemaValue`.
* Made the subscript accessor publicly accessible to allow external modules to retrieve values by `KeywordIdentifier` keys.
* Made the `merge` method publicly accessible to enable external modules to combine two `SchemaValue` instances.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.
