### PR TITLE
Mark macro extension as private/fileprivate

### DIFF
--- a/Sources/JSONSchemaMacro/Schemable/SchemableMacro.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SchemableMacro.swift
@@ -23,7 +23,8 @@ public struct SchemableMacro: MemberMacro, ExtensionMacro {
     // Get the access level from the declaration
     let accessLevel = declaration.modifiers.first { modifier in
       ["private", "fileprivate"].contains(modifier.name.text)
-    }?.name.text
+    }?
+    .name.text
 
     // Create extension with access level if present
     let extensionDecl = try ExtensionDeclSyntax(

--- a/Sources/JSONSchemaMacro/Schemable/SchemableMacro.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SchemableMacro.swift
@@ -20,9 +20,19 @@ public struct SchemableMacro: MemberMacro, ExtensionMacro {
     conformingTo protocols: [TypeSyntax],
     in context: some MacroExpansionContext
   ) throws -> [ExtensionDeclSyntax] {
-    let schemableExtension = try ExtensionDeclSyntax("extension \(type.trimmed): Schemable {}")
+    // Get the access level from the declaration
+    let accessLevel = declaration.modifiers.first { modifier in
+      ["private", "fileprivate"].contains(modifier.name.text)
+    }?.name.text
 
-    return [schemableExtension]
+    // Create extension with access level if present
+    let extensionDecl = try ExtensionDeclSyntax(
+      """
+      \(raw: accessLevel.map { "\($0) " } ?? "")extension \(type.trimmed): Schemable {}
+      """
+    )
+
+    return [extensionDecl]
   }
 
   public static func expansion(

--- a/Tests/JSONSchemaMacroTests/SchemableEnumExpansionTests.swift
+++ b/Tests/JSONSchemaMacroTests/SchemableEnumExpansionTests.swift
@@ -599,7 +599,7 @@ import Testing
           }
         }
 
-        extension TemperatureKind: Schemable {
+        \(modifier == "private" || modifier == "fileprivate" ? "\(modifier) " : "")extension TemperatureKind: Schemable {
         }
         """,
       macros: testMacros

--- a/Tests/JSONSchemaMacroTests/SchemableExpansionTests.swift
+++ b/Tests/JSONSchemaMacroTests/SchemableExpansionTests.swift
@@ -384,7 +384,7 @@ struct SchemableExpansionTests {
           }
         }
 
-        extension Weather: Schemable {
+        \(modifier == "private" || modifier == "fileprivate" ? "\(modifier) " : "")extension Weather: Schemable {
         }
         """,
       macros: testMacros


### PR DESCRIPTION
## Description

This pull request updates the `SchemableMacro` implementation to respect the access level of the original declaration when generating extensions and adjusts related test cases to validate this behavior. The most important changes include modifying the macro logic to include access level modifiers and updating test cases to reflect this new functionality.

### Updates to `SchemableMacro` implementation:

* [`Sources/JSONSchemaMacro/Schemable/SchemableMacro.swift`](diffhunk://#diff-d22bc6754211dd37ffd685fc4f5e2f22d9022571e1973b1c26fb23ee512136f6L23-R35): Modified the macro to extract the access level (`private` or `fileprivate`) from the declaration and include it in the generated extension syntax. 

### Adjustments to test cases:

* [`Tests/JSONSchemaMacroTests/SchemableEnumExpansionTests.swift`](diffhunk://#diff-9b41da34990b724ac2fbb50c399560691edb9c27ef637a76280d827affdf24b9L602-R602): Updated test cases to verify that the generated `Schemable` extensions include the correct `private` or `fileprivate` modifier when applicable.
* [`Tests/JSONSchemaMacroTests/SchemableExpansionTests.swift`](diffhunk://#diff-8fcbc1ebf9e8a21ff9f1ea23bd3ec6c8be2a99b2462ebf5618bc04ef7000aed2L387-R387): Similarly updated test cases to ensure the generated `Schemable` extensions for structs respect the access level of the original declaration.

Closes #72 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.
