### PR TITLE
Add format validator support

### DIFF
--- a/Sources/JSONSchema/FormatValidators/BuiltinValidators.swift
+++ b/Sources/JSONSchema/FormatValidators/BuiltinValidators.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+// MARK: - Date and Time
+
+public struct DateTimeFormatValidator: FormatValidator {
+  public let formatName = "date-time"
+  private static let formatter: ISO8601DateFormatter = {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return f
+  }()
+
+  public func validate(_ value: String) -> Bool {
+    DateTimeFormatValidator.formatter.date(from: value) != nil
+  }
+}
+
+public struct DateFormatValidator: FormatValidator {
+  public let formatName = "date"
+  private static let formatter: DateFormatter = {
+    let f = DateFormatter()
+    f.locale = Locale(identifier: "en_US_POSIX")
+    f.dateFormat = "yyyy-MM-dd"
+    f.timeZone = TimeZone(secondsFromGMT: 0)
+    return f
+  }()
+
+  public func validate(_ value: String) -> Bool {
+    DateFormatValidator.formatter.date(from: value) != nil
+  }
+}
+
+public struct TimeFormatValidator: FormatValidator {
+  public let formatName = "time"
+  private static let regex = try! Regex(#"^(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):?[0-5]\d)?$"#)
+
+  public func validate(_ value: String) -> Bool {
+    value.firstMatch(of: Self.regex) != nil
+  }
+}
+
+// MARK: - Network/IDs
+
+public struct EmailFormatValidator: FormatValidator {
+  public let formatName = "email"
+  private static let regex = try! Regex(#"^[^@\s]+@[^@\s]+\.[^@\s]+$"#)
+  public func validate(_ value: String) -> Bool { value.firstMatch(of: Self.regex) != nil }
+}
+
+public struct HostnameFormatValidator: FormatValidator {
+  public let formatName = "hostname"
+  private static let regex = try! Regex(#"^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)(?:\.(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?))*$"#)
+  public func validate(_ value: String) -> Bool { value.firstMatch(of: Self.regex) != nil }
+}
+
+public struct IPv4FormatValidator: FormatValidator {
+  public let formatName = "ipv4"
+  private static let regex = try! Regex(#"^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}$"#)
+  public func validate(_ value: String) -> Bool { value.firstMatch(of: Self.regex) != nil }
+}
+
+public struct IPv6FormatValidator: FormatValidator {
+  public let formatName = "ipv6"
+  private static let regex = try! Regex(#"^(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}$"#)
+  public func validate(_ value: String) -> Bool { value.firstMatch(of: Self.regex) != nil }
+}
+
+public struct UUIDFormatValidator: FormatValidator {
+  public let formatName = "uuid"
+  public func validate(_ value: String) -> Bool { UUID(uuidString: value) != nil }
+}
+
+public struct URIFormatValidator: FormatValidator {
+  public let formatName = "uri"
+  public func validate(_ value: String) -> Bool {
+    guard let url = URL(string: value) else { return false }
+    return url.scheme != nil
+  }
+}
+
+public struct URIReferenceFormatValidator: FormatValidator {
+  public let formatName = "uri-reference"
+  public func validate(_ value: String) -> Bool {
+    URL(string: value) != nil
+  }
+}

--- a/Sources/JSONSchema/FormatValidators/BuiltinValidators.swift
+++ b/Sources/JSONSchema/FormatValidators/BuiltinValidators.swift
@@ -32,7 +32,9 @@ public struct DateFormatValidator: FormatValidator {
 
 public struct TimeFormatValidator: FormatValidator {
   public let formatName = "time"
-  private static let regex = try! Regex(#"^(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):?[0-5]\d)?$"#)
+  private static let regex = try! Regex(
+    #"^(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):?[0-5]\d)?$"#
+  )
 
   public func validate(_ value: String) -> Bool {
     value.firstMatch(of: Self.regex) != nil
@@ -49,13 +51,17 @@ public struct EmailFormatValidator: FormatValidator {
 
 public struct HostnameFormatValidator: FormatValidator {
   public let formatName = "hostname"
-  private static let regex = try! Regex(#"^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)(?:\.(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?))*$"#)
+  private static let regex = try! Regex(
+    #"^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)(?:\.(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?))*$"#
+  )
   public func validate(_ value: String) -> Bool { value.firstMatch(of: Self.regex) != nil }
 }
 
 public struct IPv4FormatValidator: FormatValidator {
   public let formatName = "ipv4"
-  private static let regex = try! Regex(#"^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}$"#)
+  private static let regex = try! Regex(
+    #"^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}$"#
+  )
   public func validate(_ value: String) -> Bool { value.firstMatch(of: Self.regex) != nil }
 }
 

--- a/Sources/JSONSchema/FormatValidators/FormatValidator.swift
+++ b/Sources/JSONSchema/FormatValidators/FormatValidator.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public protocol FormatValidator: Sendable {
+  /// The name of the format that this validator is responsible for.
+  var formatName: String { get }
+  /// Returns `true` if the provided string is valid for this format.
+  func validate(_ value: String) -> Bool
+}
+
+public enum DefaultFormatValidators {
+  /// Collection of the default validators provided by ``JSONSchema``.
+  public static var all: [any FormatValidator] {
+    [
+      DateTimeFormatValidator(),
+      DateFormatValidator(),
+      TimeFormatValidator(),
+      EmailFormatValidator(),
+      HostnameFormatValidator(),
+      IPv4FormatValidator(),
+      IPv6FormatValidator(),
+      UUIDFormatValidator(),
+      URIFormatValidator(),
+      URIReferenceFormatValidator(),
+    ]
+  }
+}

--- a/Sources/JSONSchema/Keywords/Keywords+Assertion.swift
+++ b/Sources/JSONSchema/Keywords/Keywords+Assertion.swift
@@ -347,7 +347,15 @@ extension Keywords {
       at location: JSONPointer,
       using annotations: AnnotationContainer
     ) throws(ValidationIssue) {
-      // TODO: Support format keyword
+      guard
+        let formatName = value.string,
+        let string = input.string,
+        let validator = context.context.formatValidators[formatName]
+      else { return }
+
+      if !validator.validate(string) {
+        throw ValidationIssue.invalidFormat(name: formatName, value: string)
+      }
     }
   }
 }

--- a/Sources/JSONSchema/Schema.swift
+++ b/Sources/JSONSchema/Schema.swift
@@ -41,10 +41,18 @@ public struct Schema: ValidatableSchema {
     instance: String,
     dialect: Dialect = .draft2020_12,
     decoder: JSONDecoder = .init(),
-    remoteSchemas: [String: JSONValue] = [:]
+    remoteSchemas: [String: JSONValue] = [:],
+    formatValidators: [any FormatValidator] = []
   ) throws {
     let value = try decoder.decode(JSONValue.self, from: Data(instance.utf8))
-    try self.init(rawSchema: value, context: .init(dialect: dialect, remoteSchema: remoteSchemas))
+    try self.init(
+      rawSchema: value,
+      context: .init(
+        dialect: dialect,
+        remoteSchema: remoteSchemas,
+        formatValidators: formatValidators
+      )
+    )
   }
 
   init(schema: any ValidatableSchema, location: JSONPointer, context: Context) {

--- a/Sources/JSONSchema/Validation/Context.swift
+++ b/Sources/JSONSchema/Validation/Context.swift
@@ -15,6 +15,9 @@ public final class Context: Sendable {
 
   var dynamicScopes: [[String: JSONPointer]] = []
 
+  /// Validators used when the ``Keywords.Format`` keyword is present.
+  var formatValidators: [String: any FormatValidator] = [:]
+
   /// A dictionary that tracks whether the `minContains` constraint is effectively zero
   /// for specific schema locations.
   ///
@@ -34,8 +37,15 @@ public final class Context: Sendable {
   ///   conditional validation at the specified schema location.
   var ifConditionalResults = [JSONPointer: ValidationResult]()
 
-  public init(dialect: Dialect, remoteSchema: [String: JSONValue] = [:]) {
+  public init(
+    dialect: Dialect,
+    remoteSchema: [String: JSONValue] = [:],
+    formatValidators: [any FormatValidator] = []
+  ) {
     self.dialect = dialect
     self.remoteSchemaStorage = remoteSchema
+    self.formatValidators = Dictionary(
+      uniqueKeysWithValues: formatValidators.map { ($0.formatName, $0) }
+    )
   }
 }

--- a/Sources/JSONSchema/Validation/Errors/ValidationIssue.swift
+++ b/Sources/JSONSchema/Validation/Errors/ValidationIssue.swift
@@ -14,6 +14,7 @@ public enum ValidationIssue: Error, Codable, Equatable {
   case exceedsMaxLength(string: String, maxLength: Int)
   case belowMinLength(string: String, minLength: Int)
   case patternMismatch(string: String, pattern: String)
+  case invalidFormat(name: String, value: String)
 
   // Arrays
   case exceedsMaxItems(count: Int, maxItems: Int)
@@ -116,6 +117,8 @@ extension ValidationIssue: CustomStringConvertible {
       return "String '\(string)' is shorter than minimum length of \(minLength)"
     case .patternMismatch(let string, let pattern):
       return "String '\(string)' does not match pattern '\(pattern)'"
+    case .invalidFormat(let name, let value):
+      return "String '\(value)' is not valid for format '\(name)'"
 
     // Arrays
     case .exceedsMaxItems(let count, let maxItems):

--- a/Tests/JSONSchemaTests/FormatValidatorTests.swift
+++ b/Tests/JSONSchemaTests/FormatValidatorTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+
+@testable import JSONSchema
+
+struct FormatValidatorTests {
+  @Test(arguments: [
+    ("2024-01-01T12:00:00.000Z", true),
+    ("2024-01-01T12:00:00Z", false),
+  ])
+  func dateTimeValidator(value: String, isValid: Bool) {
+    let validator = DateTimeFormatValidator()
+    #expect(validator.validate(value) == isValid)
+  }
+
+  @Test(arguments: [
+    ("2024-01-01", true),
+    ("01-01-2024", false),
+  ])
+  func dateValidator(value: String, isValid: Bool) {
+    let validator = DateFormatValidator()
+    #expect(validator.validate(value) == isValid)
+  }
+
+  @Test(arguments: [
+    ("12:34:56Z", true),
+    ("12:34", false),
+  ])
+  func timeValidator(value: String, isValid: Bool) {
+    let validator = TimeFormatValidator()
+    #expect(validator.validate(value) == isValid)
+  }
+
+  @Test(arguments: [
+    ("test@example.com", true),
+    ("invalid", false),
+  ])
+  func emailValidator(value: String, isValid: Bool) {
+    let validator = EmailFormatValidator()
+    #expect(validator.validate(value) == isValid)
+  }
+
+  @Test(arguments: [
+    ("example.com", true),
+    ("-invalid", false),
+  ])
+  func hostnameValidator(value: String, isValid: Bool) {
+    let validator = HostnameFormatValidator()
+    #expect(validator.validate(value) == isValid)
+  }
+
+  @Test(arguments: [
+    ("192.168.0.1", true),
+    ("256.256.256.256", false),
+  ])
+  func ipv4Validator(value: String, isValid: Bool) {
+    let validator = IPv4FormatValidator()
+    #expect(validator.validate(value) == isValid)
+  }
+
+  @Test(arguments: [
+    ("2001:0db8:85a3:0000:0000:8a2e:0370:7334", true),
+    ("2001:db8::1", false),
+  ])
+  func ipv6Validator(value: String, isValid: Bool) {
+    let validator = IPv6FormatValidator()
+    #expect(validator.validate(value) == isValid)
+  }
+
+  @Test(arguments: [
+    ("00000000-0000-0000-0000-000000000000", true),
+    ("not-a-uuid", false),
+  ])
+  func uuidValidator(value: String, isValid: Bool) {
+    let validator = UUIDFormatValidator()
+    #expect(validator.validate(value) == isValid)
+  }
+
+  @Test(arguments: [
+    ("https://example.com", true),
+    ("ht!tp://example.com", false),
+  ])
+  func uriValidator(value: String, isValid: Bool) {
+    let validator = URIFormatValidator()
+    #expect(validator.validate(value) == isValid)
+  }
+
+  @Test(arguments: [
+    ("foo/bar", true),
+    ("ht!tp://example.com", false),
+  ])
+  func uriReferenceValidator(value: String, isValid: Bool) {
+    let validator = URIReferenceFormatValidator()
+    #expect(validator.validate(value) == isValid)
+  }
+}

--- a/Tests/JSONSchemaTests/KeywordTests.swift
+++ b/Tests/JSONSchemaTests/KeywordTests.swift
@@ -308,6 +308,36 @@ struct KeywordTests {
       }
     }
 
+    @Test(arguments: [
+      (JSONValue.string("test@example.com"), true),
+      (JSONValue.string("invalid"), false),
+      (JSONValue.number(1), true),
+      (JSONValue.null, true),
+    ])
+    func format(instance: JSONValue, isValid: Bool) {
+      let schemaValue: JSONValue = "email"
+      let annotations = AnnotationContainer()
+      let context = KeywordContext(
+        context: Context(
+          dialect: .draft2020_12,
+          formatValidators: [EmailFormatValidator()]
+        )
+      )
+      let keyword = Keywords.Format(value: schemaValue, context: context)
+
+      if isValid {
+        #expect(throws: Never.self) {
+          try keyword.validate(instance, at: .init(), using: annotations)
+        }
+      } else {
+        #expect(
+          throws: ValidationIssue.invalidFormat(name: "email", value: instance.string ?? "")
+        ) {
+          try keyword.validate(instance, at: .init(), using: annotations)
+        }
+      }
+    }
+
     // MARK: - Arrays
 
     @Test(arguments: [

--- a/Tests/JSONSchemaTests/SchemaTests.swift
+++ b/Tests/JSONSchemaTests/SchemaTests.swift
@@ -109,4 +109,25 @@ struct SchemaTests {
     let result = metaSchema.validate(.object(["minLength": 1]))
     #expect(result.isValid == true)
   }
+
+  @Test func formatValidators() throws {
+    let rawSchema: JSONValue = [
+      "type": "string",
+      "format": "uuid",
+    ]
+
+    let valid: JSONValue = .string("00000000-0000-0000-0000-000000000000")
+    let invalid: JSONValue = .string("not-a-uuid")
+
+    let schema = try Schema(
+      rawSchema: rawSchema,
+      context: Context(
+        dialect: .draft2020_12,
+        formatValidators: [UUIDFormatValidator()]
+      )
+    )
+
+    #expect(schema.validate(valid).isValid)
+    #expect(schema.validate(invalid).isValid == false)
+  }
 }


### PR DESCRIPTION
## Summary
- implement protocol-based format validation
- support common format validators
- validate `format` keyword when validators provided
- allow supplying validators when building `Context` or initializing `Schema`
- test format keyword and validators
- add dedicated tests for each built-in `FormatValidator`

Closes #44


## Testing
- `swift test --filter KeywordTests/AssertionKeywords/format`
- `swift test --filter SchemaTests/formatValidators`
- `swift test --filter FormatValidatorTests`


------
https://chatgpt.com/codex/tasks/task_e_6841dd09f2848331a3defa836866b2d5