### PR TITLE
Add boolean additionalProperties overload

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,7 @@ struct Person {
                   """#)
               }
           }
-          .additionalProperties {
-              false
-          }
-          // Drop the parse information. Use custom builder if needed.
-          .map {
-              $0.0
-          }
+          .additionalProperties(false)
       }
     }
   }

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONObject.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONObject.swift
@@ -75,6 +75,23 @@ extension JSONSchemaComponent {
     )
   }
 
+  /// Adds a constant additional properties flag to the schema.
+  /// - Parameter flag: A boolean value that will be used for the
+  ///   ``Keywords.AdditionalProperties`` keyword.
+  /// - Returns: A copy of the receiver with the keyword set.
+  public func additionalProperties(_ flag: Bool) -> Self {
+    var copy = self
+    copy.schemaValue[Keywords.AdditionalProperties.name] = .boolean(flag)
+    return copy
+  }
+
+  /// Adds a constant additional properties flag using a ``JSONBooleanSchema``.
+  /// - Parameter flag: The boolean schema used for the keyword.
+  /// - Returns: A copy of the receiver with the keyword set.
+  public func additionalProperties(_ flag: JSONBooleanSchema) -> Self {
+    additionalProperties(flag.value)
+  }
+
   /// Adds unevaluated properties to the schema.
   /// - Parameter content: A closure that returns a JSON schema representing the unevaluated properties.
   /// - Returns: A new `JSONObject` with the unevaluated properties set.

--- a/Sources/JSONSchemaBuilder/Macros/SchemaOptions/TypeSpecific/ObjectOptions.swift
+++ b/Sources/JSONSchemaBuilder/Macros/SchemaOptions/TypeSpecific/ObjectOptions.swift
@@ -21,6 +21,10 @@ extension ObjectTrait where Self == ObjectSchemaTrait {
     fatalError(ObjectSchemaTrait.errorMessage)
   }
 
+  public static func additionalProperties(_ flag: Bool) -> ObjectSchemaTrait {
+    fatalError(ObjectSchemaTrait.errorMessage)
+  }
+
   public static func patternProperties(
     @JSONPropertySchemaBuilder _ patternProperties: @escaping () -> some PropertyCollection
   ) -> ObjectSchemaTrait {

--- a/Sources/JSONSchemaMacro/Schemable/SchemaOptionsGenerator.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SchemaOptionsGenerator.swift
@@ -45,7 +45,19 @@ enum SchemaOptionsGenerator {
     to codeBlockItem: CodeBlockItemSyntax
   ) -> CodeBlockItemSyntax {
     switch optionName {
-    case "additionalProperties", "patternProperties":
+    case "additionalProperties":
+      if closure.statements.count == 1,
+        let first = closure.statements.first,
+        let expr = first.item.as(ExprSyntax.self),
+        let bool = expr.as(BooleanLiteralExprSyntax.self)
+      {
+        return """
+          \(codeBlockItem)
+          .additionalProperties(\(raw: bool.literal.text))
+          """
+      }
+      fallthrough
+    case "patternProperties":
       return """
         \(codeBlockItem)
         .\(raw: optionName) { \(closure.statements) }

--- a/Sources/JSONSchemaMacro/Schemable/SchemaOptionsGenerator.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SchemaOptionsGenerator.swift
@@ -56,6 +56,7 @@ enum SchemaOptionsGenerator {
           .additionalProperties(\(raw: bool.literal.text))
           """
       }
+      // Intentionally fall through to "patternProperties" to handle shared logic.
       fallthrough
     case "patternProperties":
       return """

--- a/Tests/JSONSchemaBuilderTests/ParsingTests.swift
+++ b/Tests/JSONSchemaBuilderTests/ParsingTests.swift
@@ -78,4 +78,20 @@ struct ParsingTests {
       )
     }
   }
+
+  @Test func additionalPropertiesFalseValidation() throws {
+    @JSONSchemaBuilder var sample: some JSONSchemaComponent<Void> {
+      JSONObject()
+        .additionalProperties(false)
+    }
+
+    let input: JSONValue = ["extra": true]
+
+    let result = sample.parse(input)
+    #expect(result.value != nil)
+
+    #expect(throws: ParseAndValidateIssue.self) {
+      _ = try sample.parseAndValidate(instance: "{\"extra\": true}")
+    }
+  }
 }

--- a/Tests/JSONSchemaMacroTests/TypeSpecificSchemaOptionsTests.swift
+++ b/Tests/JSONSchemaMacroTests/TypeSpecificSchemaOptionsTests.swift
@@ -186,13 +186,7 @@ struct ObjectOptionsTests {
                 }
                 .required()
               }
-              .additionalProperties {
-                false
-              }
-              // Drop the parse information. Use custom builder if needed.
-              .map {
-                $0.0
-              }
+              .additionalProperties(false)
             }
           }
         }


### PR DESCRIPTION
## Summary
- support simple `.additionalProperties(true/false)` in JSON object builder
- detect constant boolean additionalProperties in macros
- update macro tests and README accordingly
- test that additionalProperties(false) validates via parse-and-validate

## Testing
- `make format`
- `swift test`

Closes #20

------
https://chatgpt.com/codex/tasks/task_e_6841fb22637c8331ac479b9b5da30953