### PR TITLE
Add identifier keyword support

### DIFF
--- a/Sources/JSONSchema/Keywords/Keywords+Identifier.swift
+++ b/Sources/JSONSchema/Keywords/Keywords+Identifier.swift
@@ -6,11 +6,16 @@ protocol IdentifierKeyword: Keyword {
 
 extension Keywords {
   /// https://json-schema.org/draft/2020-12/json-schema-core#name-the-id-keyword
-  struct Identifier: IdentifierKeyword {
-    static let name = "$id"
+  package struct Identifier: IdentifierKeyword {
+    package static let name = "$id"
 
-    let value: JSONValue
-    let context: KeywordContext
+    package let value: JSONValue
+    package let context: KeywordContext
+
+    package init(value: JSONValue, context: KeywordContext) {
+      self.value = value
+      self.context = context
+    }
 
     func processIdentifier() {}
 
@@ -25,11 +30,16 @@ extension Keywords {
     }
   }
 
-  struct Defs: IdentifierKeyword {
-    static let name = "$defs"
+  package struct Defs: IdentifierKeyword {
+    package static let name = "$defs"
 
-    let value: JSONValue
-    let context: KeywordContext
+    package let value: JSONValue
+    package let context: KeywordContext
+
+    package init(value: JSONValue, context: KeywordContext) {
+      self.value = value
+      self.context = context
+    }
 
     func processIdentifier() {
       guard case .object(let object) = value else { return }
@@ -46,11 +56,16 @@ extension Keywords {
     }
   }
 
-  struct Anchor: IdentifierKeyword {
-    static let name = "$anchor"
+  package struct Anchor: IdentifierKeyword {
+    package static let name = "$anchor"
 
-    let value: JSONValue
-    let context: KeywordContext
+    package let value: JSONValue
+    package let context: KeywordContext
+
+    package init(value: JSONValue, context: KeywordContext) {
+      self.value = value
+      self.context = context
+    }
 
     func processIdentifier() {
       guard let anchorName = value.string else { return }
@@ -64,11 +79,16 @@ extension Keywords {
     }
   }
 
-  struct DynamicAnchor: IdentifierKeyword {
-    static let name = "$dynamicAnchor"
+  package struct DynamicAnchor: IdentifierKeyword {
+    package static let name = "$dynamicAnchor"
 
-    let value: JSONValue
-    let context: KeywordContext
+    package let value: JSONValue
+    package let context: KeywordContext
+
+    package init(value: JSONValue, context: KeywordContext) {
+      self.value = value
+      self.context = context
+    }
 
     func processIdentifier() {
       guard let anchorName = value.string else { return }

--- a/Sources/JSONSchema/Keywords/Keywords+Reference.swift
+++ b/Sources/JSONSchema/Keywords/Keywords+Reference.swift
@@ -11,15 +11,15 @@ protocol ReferenceKeyword: Keyword {
 }
 
 extension Keywords {
-  struct Reference: ReferenceKeyword {
-    static let name = "$ref"
+  package struct Reference: ReferenceKeyword {
+    package static let name = "$ref"
 
-    let value: JSONValue
-    let context: KeywordContext
+    package let value: JSONValue
+    package let context: KeywordContext
     private let referenceURI: String
     private let resolver: ReferenceResolver
 
-    init(value: JSONValue, context: KeywordContext) {
+    package init(value: JSONValue, context: KeywordContext) {
       self.value = value
       self.context = context
       self.referenceURI = value.string ?? ""
@@ -59,15 +59,15 @@ extension Keywords {
     }
   }
 
-  struct DynamicReference: ReferenceKeyword {
-    static let name = "$dynamicRef"
+  package struct DynamicReference: ReferenceKeyword {
+    package static let name = "$dynamicRef"
 
-    let value: JSONValue
-    let context: KeywordContext
+    package let value: JSONValue
+    package let context: KeywordContext
     private let referenceURI: String
     private let resolver: ReferenceResolver
 
-    init(value: JSONValue, context: KeywordContext) {
+    package init(value: JSONValue, context: KeywordContext) {
       self.value = value
       self.context = context
       self.referenceURI = value.string ?? ""

--- a/Sources/JSONSchema/Keywords/Keywords+Reserved.swift
+++ b/Sources/JSONSchema/Keywords/Keywords+Reserved.swift
@@ -1,31 +1,51 @@
 protocol ReservedKeyword: Keyword {}
 
 extension Keywords {
-  struct Defintions: ReservedKeyword {
-    static let name = "defintions"
+  package struct Defintions: ReservedKeyword {
+    package static let name = "defintions"
 
-    let value: JSONValue
-    let context: KeywordContext
+    package let value: JSONValue
+    package let context: KeywordContext
+
+    package init(value: JSONValue, context: KeywordContext) {
+      self.value = value
+      self.context = context
+    }
   }
 
-  struct Dependencies: ReservedKeyword {
-    static let name = "dependencies"
+  package struct Dependencies: ReservedKeyword {
+    package static let name = "dependencies"
 
-    let value: JSONValue
-    let context: KeywordContext
+    package let value: JSONValue
+    package let context: KeywordContext
+
+    package init(value: JSONValue, context: KeywordContext) {
+      self.value = value
+      self.context = context
+    }
   }
 
-  struct RecursiveAnchor: ReservedKeyword {
-    static let name = "$recursiveAnchor"
+  package struct RecursiveAnchor: ReservedKeyword {
+    package static let name = "$recursiveAnchor"
 
-    let value: JSONValue
-    let context: KeywordContext
+    package let value: JSONValue
+    package let context: KeywordContext
+
+    package init(value: JSONValue, context: KeywordContext) {
+      self.value = value
+      self.context = context
+    }
   }
 
-  struct RecursiveReference: ReservedKeyword {
-    static let name = "$recursiveRef"
+  package struct RecursiveReference: ReservedKeyword {
+    package static let name = "$recursiveRef"
 
-    let value: JSONValue
-    let context: KeywordContext
+    package let value: JSONValue
+    package let context: KeywordContext
+
+    package init(value: JSONValue, context: KeywordContext) {
+      self.value = value
+      self.context = context
+    }
   }
 }

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent+Identifiers.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent+Identifiers.swift
@@ -1,0 +1,57 @@
+import JSONSchema
+
+extension JSONSchemaComponent {
+  public func id(_ value: String) -> Self {
+    var copy = self
+    copy.schemaValue[Keywords.Identifier.name] = .string(value)
+    return copy
+  }
+
+  public func schema(_ uri: String) -> Self {
+    var copy = self
+    copy.schemaValue[Keywords.SchemaKeyword.name] = .string(uri)
+    return copy
+  }
+
+  public func vocabulary(_ mapping: [String: Bool]) -> Self {
+    var copy = self
+    copy.schemaValue[Keywords.Vocabulary.name] = .object(Dictionary(uniqueKeysWithValues: mapping.map { ($0.key, .boolean($0.value)) }))
+    return copy
+  }
+
+  public func anchor(_ name: String) -> Self {
+    var copy = self
+    copy.schemaValue[Keywords.Anchor.name] = .string(name)
+    return copy
+  }
+
+  public func dynamicAnchor(_ name: String) -> Self {
+    var copy = self
+    copy.schemaValue[Keywords.DynamicAnchor.name] = .string(name)
+    return copy
+  }
+
+  public func dynamicRef(_ uri: String) -> Self {
+    var copy = self
+    copy.schemaValue[Keywords.DynamicReference.name] = .string(uri)
+    return copy
+  }
+
+  public func ref(_ uri: String) -> Self {
+    var copy = self
+    copy.schemaValue[Keywords.Reference.name] = .string(uri)
+    return copy
+  }
+
+  public func recursiveAnchor(_ name: String) -> Self {
+    var copy = self
+    copy.schemaValue[Keywords.RecursiveAnchor.name] = .string(name)
+    return copy
+  }
+
+  public func recursiveRef(_ uri: String) -> Self {
+    var copy = self
+    copy.schemaValue[Keywords.RecursiveReference.name] = .string(uri)
+    return copy
+  }
+}

--- a/Tests/JSONSchemaBuilderTests/JSONIdentifierTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONIdentifierTests.swift
@@ -1,0 +1,42 @@
+import JSONSchema
+import Testing
+
+@testable import JSONSchemaBuilder
+
+struct JSONIdentifierBuilderTests {
+  @Test func identifierKeywords() throws {
+    @JSONSchemaBuilder var sample: some JSONSchemaComponent {
+      JSONString()
+        .id("https://example.com/schema")
+        .schema("https://json-schema.org/draft/2020-12/schema")
+        .vocabulary([
+          "https://example.com/vocab/core": true,
+          "https://example.com/vocab/other": false
+        ])
+        .anchor("nameAnchor")
+        .dynamicAnchor("dynAnchor")
+        .dynamicRef("#dynAnchor")
+        .ref("#someRef")
+        .recursiveAnchor("recAnchor")
+        .recursiveRef("#recAnchor")
+    }
+
+    let expected: [String: JSONValue] = [
+      "$id": "https://example.com/schema",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$vocabulary": [
+        "https://example.com/vocab/core": true,
+        "https://example.com/vocab/other": false
+      ],
+      "$anchor": "nameAnchor",
+      "$dynamicAnchor": "dynAnchor",
+      "$dynamicRef": "#dynAnchor",
+      "$ref": "#someRef",
+      "$recursiveAnchor": "recAnchor",
+      "$recursiveRef": "#recAnchor",
+      "type": "string",
+    ]
+
+    #expect(sample.schemaValue == .object(expected))
+  }
+}


### PR DESCRIPTION
## Summary
- allow builder to set identifier-related keywords
- expose identifier, reference and reserved keywords package-wide
- test that identifier keywords are emitted in schemas

## Testing
- `swift test -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ff22a68483318757f05460bbdc83