### PR TITLE
Improve wrapper names and runtime support

### DIFF
--- a/Sources/JSONSchema/Validation/ValidationResult.swift
+++ b/Sources/JSONSchema/Validation/ValidationResult.swift
@@ -1,4 +1,4 @@
-public struct ValidationResult: Sendable, Encodable {
+public struct ValidationResult: Sendable, Encodable, Equatable {
   public let isValid: Bool
   public let keywordLocation: JSONPointer
   public let instanceLocation: JSONPointer
@@ -36,6 +36,13 @@ public struct ValidationResult: Sendable, Encodable {
       annotations?.map { AnyAnnotationWrapper(annotation: $0) },
       forKey: .annotations
     )
+  }
+
+  public static func == (lhs: ValidationResult, rhs: ValidationResult) -> Bool {
+    return lhs.isValid == rhs.isValid
+    && lhs.keywordLocation == rhs.keywordLocation
+    && lhs.instanceLocation == rhs.instanceLocation
+    && lhs.errors == rhs.errors
   }
 }
 

--- a/Sources/JSONSchema/Validation/ValidationResult.swift
+++ b/Sources/JSONSchema/Validation/ValidationResult.swift
@@ -39,10 +39,10 @@ public struct ValidationResult: Sendable, Encodable, Equatable {
   }
 
   public static func == (lhs: ValidationResult, rhs: ValidationResult) -> Bool {
-    return lhs.isValid == rhs.isValid
-    && lhs.keywordLocation == rhs.keywordLocation
-    && lhs.instanceLocation == rhs.instanceLocation
-    && lhs.errors == rhs.errors
+    lhs.isValid == rhs.isValid
+      && lhs.keywordLocation == rhs.keywordLocation
+      && lhs.instanceLocation == rhs.instanceLocation
+      && lhs.errors == rhs.errors
   }
 }
 

--- a/Sources/JSONSchemaBuilder/Builders/JSONPropertySchemaBuilder.swift
+++ b/Sources/JSONSchemaBuilder/Builders/JSONPropertySchemaBuilder.swift
@@ -16,7 +16,7 @@ import JSONSchema
 
   public static func buildOptional<Component: PropertyCollection>(
     _ component: Component?
-  ) -> JSONPropertyComponents.OptionalNoType<Component> { .init(wrapped: component) }
+  ) -> JSONPropertyComponents.OptionalComponent<Component> { .init(wrapped: component) }
 
   public static func buildEither<TrueComponent, FalseComponent>(
     first component: TrueComponent

--- a/Sources/JSONSchemaBuilder/Builders/JSONSchemaBuilder.swift
+++ b/Sources/JSONSchemaBuilder/Builders/JSONSchemaBuilder.swift
@@ -63,6 +63,8 @@ extension JSONSchemaCollectionBuilder where Output == JSONValue {
     accumulated: [JSONComponents.AnySchemaComponent<JSONValue>],
     next component: Component
   ) -> [JSONComponents.AnySchemaComponent<JSONValue>] {
-    accumulated + [JSONComponents.PassthroughComponent(wrapped: component).eraseToAnySchemaComponent()]
+    accumulated + [
+      JSONComponents.PassthroughComponent(wrapped: component).eraseToAnySchemaComponent()
+    ]
   }
 }

--- a/Sources/JSONSchemaBuilder/Builders/JSONSchemaBuilder.swift
+++ b/Sources/JSONSchemaBuilder/Builders/JSONSchemaBuilder.swift
@@ -26,7 +26,7 @@ import JSONSchema
 
   public static func buildOptional<Component: JSONSchemaComponent>(
     _ component: Component?
-  ) -> JSONComponents.OptionalNoType<Component> { .init(wrapped: component) }
+  ) -> JSONComponents.OptionalComponent<Component> { .init(wrapped: component) }
 
   public static func buildEither<TrueComponent, FalseComponent>(
     first component: TrueComponent
@@ -40,29 +40,29 @@ import JSONSchema
 @resultBuilder public enum JSONSchemaCollectionBuilder<Output> {
   public static func buildPartialBlock<Component: JSONSchemaComponent>(
     first component: Component
-  ) -> [JSONComponents.AnyComponent<Output>] where Component.Output == Output {
-    [component.eraseToAnyComponent()]
+  ) -> [JSONComponents.AnySchemaComponent<Output>] where Component.Output == Output {
+    [component.eraseToAnySchemaComponent()]
   }
 
   public static func buildPartialBlock<Component: JSONSchemaComponent>(
-    accumulated: [JSONComponents.AnyComponent<Output>],
+    accumulated: [JSONComponents.AnySchemaComponent<Output>],
     next component: Component
-  ) -> [JSONComponents.AnyComponent<Output>] where Component.Output == Output {
-    accumulated + [component.eraseToAnyComponent()]
+  ) -> [JSONComponents.AnySchemaComponent<Output>] where Component.Output == Output {
+    accumulated + [component.eraseToAnySchemaComponent()]
   }
 }
 
 extension JSONSchemaCollectionBuilder where Output == JSONValue {
   public static func buildPartialBlock<Component: JSONSchemaComponent>(
     first component: Component
-  ) -> [JSONComponents.AnyComponent<JSONValue>] {
-    [JSONComponents.Passthrough(wrapped: component).eraseToAnyComponent()]
+  ) -> [JSONComponents.AnySchemaComponent<JSONValue>] {
+    [JSONComponents.PassthroughComponent(wrapped: component).eraseToAnySchemaComponent()]
   }
 
   public static func buildPartialBlock<Component: JSONSchemaComponent>(
-    accumulated: [JSONComponents.AnyComponent<JSONValue>],
+    accumulated: [JSONComponents.AnySchemaComponent<JSONValue>],
     next component: Component
-  ) -> [JSONComponents.AnyComponent<JSONValue>] {
-    accumulated + [JSONComponents.Passthrough(wrapped: component).eraseToAnyComponent()]
+  ) -> [JSONComponents.AnySchemaComponent<JSONValue>] {
+    accumulated + [JSONComponents.PassthroughComponent(wrapped: component).eraseToAnySchemaComponent()]
   }
 }

--- a/Sources/JSONSchemaBuilder/Documentation.docc/Articles/WrapperTypes.md
+++ b/Sources/JSONSchemaBuilder/Documentation.docc/Articles/WrapperTypes.md
@@ -1,0 +1,19 @@
+# Wrapper Types
+
+The builder provides several wrappers that can modify or combine components.
+
+| Wrapper | Description |
+| --- | --- |
+| ``JSONComponents/AnySchemaComponent`` | Type erasure for heterogeneous components. |
+| ``JSONComponents/Map`` | Transforms the output of an upstream component. |
+| ``JSONComponents/CompactMap`` | Like ``Map`` but emits an error when the transform returns `nil`. |
+| ``JSONComponents/FlatMap`` | Produces a new component after parsing the upstream component. |
+| ``JSONComponents/OptionalComponent`` | Makes a wrapped component optional. If no component is provided, any value is accepted. |
+| ``JSONComponents/PassthroughComponent`` | Validates with a wrapped component but returns the original input value. |
+| ``JSONComponents/AdditionalProperties`` | Adds ``additionalProperties`` validation for objects. |
+| ``JSONComponents/PatternProperties`` | Adds ``patternProperties`` validation for objects. |
+| ``JSONComponents/Conditional`` | Stores either of two components for ``buildEither`` cases. |
+| ``JSONComposition`` wrappers | ``AnyOf``/``AllOf``/``OneOf``/``Not`` compose multiple schemas. |
+| ``JSONSchema`` | Groups several components together and optionally maps them to a new type. |
+| ``RuntimeComponent`` | Wraps a runtime ``Schema`` and validates returning the raw ``JSONValue``. |
+| ``JSONAnyValue`` init | `init(_:)` copies schema metadata from any component without validation. |

--- a/Sources/JSONSchemaBuilder/Documentation.docc/JSONSchemaBuilder.md
+++ b/Sources/JSONSchemaBuilder/Documentation.docc/JSONSchemaBuilder.md
@@ -105,6 +105,7 @@ The third example will validate that:
 - <doc:Macros>
 - <doc:Validation>
 - <doc:ValueBuilder>
+- <doc:WrapperTypes>
 
 ## See Also
 

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONAnyValue.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONAnyValue.swift
@@ -6,5 +6,12 @@ public struct JSONAnyValue: JSONSchemaComponent {
 
   public init() {}
 
+  /// Creates a `JSONAnyValue` from any other component. Validation is skipped
+  /// but the wrapped component's schema metadata is preserved.
+  public init<Component: JSONSchemaComponent>(_ component: Component) {
+    self.init()
+    self.schemaValue = component.schemaValue
+  }
+
   public func parse(_ value: JSONValue) -> Parsed<JSONValue, ParseIssue> { .valid(value) }
 }

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONComposition.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONComposition.swift
@@ -9,13 +9,13 @@ public protocol JSONComposableCollectionComponent: JSONComposableComponent {
 
   init(
     into output: Output.Type,
-    @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnyComponent<Output>]
+    @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnySchemaComponent<Output>]
   )
 }
 
 extension JSONComposableCollectionComponent where Output == JSONValue {
   init(
-    @JSONSchemaCollectionBuilder<JSONValue> _ builder: () -> [JSONComponents.AnyComponent<
+    @JSONSchemaCollectionBuilder<JSONValue> _ builder: () -> [JSONComponents.AnySchemaComponent<
       JSONValue
     >]
   ) { self.init(into: JSONValue.self, builder) }
@@ -35,7 +35,7 @@ public enum JSONComposition: Sendable {
 
     public init(
       into output: Output.Type,
-      @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnyComponent<Output>]
+      @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnySchemaComponent<Output>]
     ) {
       components = builder()
       schemaValue[Keywords.AnyOf.name] = .array(components.map(\.schemaValue.value))
@@ -64,7 +64,7 @@ public enum JSONComposition: Sendable {
 
     public init(
       into output: Output.Type,
-      @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnyComponent<Output>]
+      @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnySchemaComponent<Output>]
     ) {
       components = builder()
       schemaValue[Keywords.AllOf.name] = .array(components.map(\.schemaValue.value))
@@ -102,7 +102,7 @@ public enum JSONComposition: Sendable {
 
     public init(
       into output: Output.Type,
-      @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnyComponent<Output>]
+      @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnySchemaComponent<Output>]
     ) {
       components = builder()
       schemaValue[Keywords.OneOf.name] = .array(components.map(\.schemaValue.value))

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONComposition.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONComposition.swift
@@ -9,7 +9,9 @@ public protocol JSONComposableCollectionComponent: JSONComposableComponent {
 
   init(
     into output: Output.Type,
-    @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnySchemaComponent<Output>]
+    @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnySchemaComponent<
+      Output
+    >]
   )
 }
 
@@ -35,7 +37,9 @@ public enum JSONComposition: Sendable {
 
     public init(
       into output: Output.Type,
-      @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnySchemaComponent<Output>]
+      @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnySchemaComponent<
+        Output
+      >]
     ) {
       components = builder()
       schemaValue[Keywords.AnyOf.name] = .array(components.map(\.schemaValue.value))
@@ -64,7 +68,9 @@ public enum JSONComposition: Sendable {
 
     public init(
       into output: Output.Type,
-      @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnySchemaComponent<Output>]
+      @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnySchemaComponent<
+        Output
+      >]
     ) {
       components = builder()
       schemaValue[Keywords.AllOf.name] = .array(components.map(\.schemaValue.value))
@@ -102,7 +108,9 @@ public enum JSONComposition: Sendable {
 
     public init(
       into output: Output.Type,
-      @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnySchemaComponent<Output>]
+      @JSONSchemaCollectionBuilder<Output> _ builder: () -> [JSONComponents.AnySchemaComponent<
+        Output
+      >]
     ) {
       components = builder()
       schemaValue[Keywords.OneOf.name] = .array(components.map(\.schemaValue.value))

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/AnySchemaComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/AnySchemaComponent.swift
@@ -1,12 +1,12 @@
 import JSONSchema
 
 extension JSONSchemaComponent {
-  public func eraseToAnyComponent() -> JSONComponents.AnyComponent<Self.Output> { .init(self) }
+  public func eraseToAnySchemaComponent() -> JSONComponents.AnySchemaComponent<Self.Output> { .init(self) }
 }
 
 extension JSONComponents {
   /// Component for type erasure.
-  public struct AnyComponent<Output>: JSONSchemaComponent {
+  public struct AnySchemaComponent<Output>: JSONSchemaComponent {
     private let validate: @Sendable (JSONValue) -> Parsed<Output, ParseIssue>
     public var schemaValue: SchemaValue
 

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/AnySchemaComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/AnySchemaComponent.swift
@@ -1,7 +1,9 @@
 import JSONSchema
 
 extension JSONSchemaComponent {
-  public func eraseToAnySchemaComponent() -> JSONComponents.AnySchemaComponent<Self.Output> { .init(self) }
+  public func eraseToAnySchemaComponent() -> JSONComponents.AnySchemaComponent<Self.Output> {
+    .init(self)
+  }
 }
 
 extension JSONComponents {

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/OptionalComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/OptionalComponent.swift
@@ -3,7 +3,7 @@ import JSONSchema
 extension JSONComponents {
   /// A component that makes the output of the upstream component optional.
   /// When the wrapped component is nil, the output of validation is `.valid(nil)` and the schema accepts any input.
-  public struct OptionalNoType<Wrapped: JSONSchemaComponent>: JSONSchemaComponent {
+  public struct OptionalComponent<Wrapped: JSONSchemaComponent>: JSONSchemaComponent {
     public var schemaValue: SchemaValue {
       get { wrapped?.schemaValue ?? .object([:]) }
       set { wrapped?.schemaValue = newValue }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/PassthroughComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/PassthroughComponent.swift
@@ -3,7 +3,7 @@ import JSONSchema
 extension JSONComponents {
   /// A component that performs validation on wrapped component but ignores wrapped `Output`and uses original input instead.
   /// Useful schema collections where `Output` type needs to match across schemas.
-  public struct Passthrough<Component: JSONSchemaComponent>: JSONSchemaComponent {
+  public struct PassthroughComponent<Component: JSONSchemaComponent>: JSONSchemaComponent {
     public var schemaValue: SchemaValue {
       get { wrapped.schemaValue }
       set { wrapped.schemaValue = newValue }

--- a/Sources/JSONSchemaBuilder/JSONComponent/RuntimeComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/RuntimeComponent.swift
@@ -17,7 +17,9 @@ public struct RuntimeComponent: JSONSchemaComponent {
     case .object(let dict):
       self.schemaValue = .object(dict)
     default:
-      throw UnsupportedSchemaTypeError.unsupportedType("Unsupported rawSchema type encountered: \(rawSchema)")
+      throw UnsupportedSchemaTypeError.unsupportedType(
+        "Unsupported rawSchema type encountered: \(rawSchema)"
+      )
     }
     self.schema = try Schema(rawSchema: rawSchema, context: .init(dialect: dialect))
   }

--- a/Sources/JSONSchemaBuilder/JSONComponent/RuntimeComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/RuntimeComponent.swift
@@ -11,27 +11,21 @@ public struct RuntimeComponent: JSONSchemaComponent {
   let schema: Schema
 
   public init(rawSchema: JSONValue, dialect: Dialect = .draft2020_12) throws {
-    guard case .boolean(_) = rawSchema || case .object(_) = rawSchema else {
-      throw UnsupportedSchemaTypeError.unsupportedType("Unsupported rawSchema type: \(rawSchema)")
+    switch rawSchema {
+    case .boolean(let bool):
+      self.schemaValue = .boolean(bool)
+    case .object(let dict):
+      self.schemaValue = .object(dict)
+    default:
+      throw UnsupportedSchemaTypeError.unsupportedType("Unsupported rawSchema type encountered: \(rawSchema)")
     }
     self.schema = try Schema(rawSchema: rawSchema, context: .init(dialect: dialect))
-    switch rawSchema {
-    case .boolean(let bool): self.schemaValue = .boolean(bool)
-    case .object(let dict): self.schemaValue = .object(dict)
-    default: throw UnsupportedSchemaTypeError("Unsupported rawSchema type encountered: \(rawSchema)")
-    }
   }
 
   public func parse(_ value: JSONValue) -> Parsed<JSONValue, ParseIssue> {
     let result = schema.validate(value)
     return result.isValid
       ? .valid(value)
-      : .error(
-        .compositionFailure(
-          type: .allOf,
-          reason: "runtime schema validation failed",
-          nestedErrors: []
-        )
-      )
+      : .error(.runtimeValidationIssue(result))
   }
 }

--- a/Sources/JSONSchemaBuilder/JSONComponent/RuntimeComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/RuntimeComponent.swift
@@ -1,0 +1,31 @@
+import JSONSchema
+
+/// A component that wraps a runtime ``Schema`` instance.
+/// Validation is performed using the provided schema and any valid input is
+/// returned unchanged.
+public struct RuntimeComponent: JSONSchemaComponent {
+  public var schemaValue: SchemaValue
+  let schema: Schema
+
+  public init(rawSchema: JSONValue, dialect: Dialect = .draft2020_12) throws {
+    self.schema = try Schema(rawSchema: rawSchema, context: .init(dialect: dialect))
+    switch rawSchema {
+    case .boolean(let bool): self.schemaValue = .boolean(bool)
+    case .object(let dict): self.schemaValue = .object(dict)
+    default: self.schemaValue = .object([:])
+    }
+  }
+
+  public func parse(_ value: JSONValue) -> Parsed<JSONValue, ParseIssue> {
+    let result = schema.validate(value)
+    return result.isValid
+      ? .valid(value)
+      : .error(
+        .compositionFailure(
+          type: .allOf,
+          reason: "runtime schema validation failed",
+          nestedErrors: []
+        )
+      )
+  }
+}

--- a/Sources/JSONSchemaBuilder/JSONComponent/RuntimeComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/RuntimeComponent.swift
@@ -4,15 +4,21 @@ import JSONSchema
 /// Validation is performed using the provided schema and any valid input is
 /// returned unchanged.
 public struct RuntimeComponent: JSONSchemaComponent {
+  public enum UnsupportedSchemaTypeError: Error {
+    case unsupportedType(String)
+  }
   public var schemaValue: SchemaValue
   let schema: Schema
 
   public init(rawSchema: JSONValue, dialect: Dialect = .draft2020_12) throws {
+    guard case .boolean(_) = rawSchema || case .object(_) = rawSchema else {
+      throw UnsupportedSchemaTypeError.unsupportedType("Unsupported rawSchema type: \(rawSchema)")
+    }
     self.schema = try Schema(rawSchema: rawSchema, context: .init(dialect: dialect))
     switch rawSchema {
     case .boolean(let bool): self.schemaValue = .boolean(bool)
     case .object(let dict): self.schemaValue = .object(dict)
-    default: self.schemaValue = .object([:])
+    default: throw UnsupportedSchemaTypeError("Unsupported rawSchema type encountered: \(rawSchema)")
     }
   }
 

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONArray.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONArray.swift
@@ -46,7 +46,7 @@ extension JSONArray {
   /// - Parameter prefixItems: A closure that returns an array of JSON schemas representing the prefix items.
   /// - Returns: A new `JSONArray` with the prefix items set.
   public func prefixItems(
-    @JSONSchemaCollectionBuilder<JSONValue> _ prefixItems: () -> [JSONComponents.AnyComponent<
+    @JSONSchemaCollectionBuilder<JSONValue> _ prefixItems: () -> [JSONComponents.AnySchemaComponent<
       JSONValue
     >]
   ) -> Self {

--- a/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyOptionalComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONPropertyComponent/Modifier/PropertyOptionalComponent.swift
@@ -2,7 +2,7 @@ import JSONSchema
 
 extension JSONPropertyComponents {
   /// A property collection that wraps another property collection and makes it's validation result optional.
-  public struct OptionalNoType<Wrapped: PropertyCollection>: PropertyCollection {
+  public struct OptionalComponent<Wrapped: PropertyCollection>: PropertyCollection {
     public var schemaValue: SchemaValue { wrapped?.schemaValue ?? .object([:]) }
 
     public var requiredKeys: [String] { wrapped?.requiredKeys ?? [] }

--- a/Sources/JSONSchemaBuilder/Macros/SchemaOptions/TypeSpecific/ArrayOptions.swift
+++ b/Sources/JSONSchemaBuilder/Macros/SchemaOptions/TypeSpecific/ArrayOptions.swift
@@ -36,7 +36,7 @@ extension ArrayTrait where Self == ArraySchemaTrait {
 
   public static func prefixItems(
     @JSONSchemaCollectionBuilder<JSONValue> _ prefixItems: @escaping () -> [JSONComponents
-      .AnyComponent<JSONValue>]
+      .AnySchemaComponent<JSONValue>]
   ) -> ArraySchemaTrait {
     fatalError(ArraySchemaTrait.errorMessage)
   }

--- a/Sources/JSONSchemaBuilder/Parsing/ParseIssue.swift
+++ b/Sources/JSONSchemaBuilder/Parsing/ParseIssue.swift
@@ -6,6 +6,7 @@ public enum ParseIssue: Error, Equatable, Sendable {
   case missingRequiredProperty(property: String)
   case compactMapValueNil(value: JSONValue)
   case compositionFailure(type: JSONComposition, reason: String, nestedErrors: [ParseIssue])
+  case runtimeValidationIssue(ValidationResult)
 }
 
 extension ParseIssue: CustomStringConvertible {
@@ -21,6 +22,8 @@ extension ParseIssue: CustomStringConvertible {
       "The instance `\(value)` returned nil when evaluated against compact map."
     case .compositionFailure(let type, let reason, _):
       "Composition (`\(type)`) failure: the instance \(reason)."
+    case .runtimeValidationIssue(let error):
+      "Runtime validation issue: \(error)"
     }
   }
 }

--- a/Tests/JSONSchemaBuilderTests/WrapperTests.swift
+++ b/Tests/JSONSchemaBuilderTests/WrapperTests.swift
@@ -1,0 +1,39 @@
+import JSONSchema
+import Testing
+
+@testable import JSONSchemaBuilder
+
+struct WrapperTests {
+  @Test func optionalComponent() {
+    let opt = JSONComponents.OptionalComponent<JSONString>(wrapped: nil)
+    let result = opt.parse(.string("hi"))
+    switch result {
+    case .valid(let value):
+      #expect(value == nil)
+    default:
+      #expect(false, "expected valid result")
+    }
+  }
+
+  @Test func erasedComponent() {
+    let any = JSONString().eraseToAnySchemaComponent()
+    #expect(any.schemaValue == JSONString().schemaValue)
+  }
+
+  @Test func passthrough() {
+    let passthrough = JSONComponents.PassthroughComponent(wrapped: JSONString())
+    let result = passthrough.parse(.string("hi"))
+    #expect(result.value == .string("hi"))
+  }
+
+  @Test func runtimeComponent() throws {
+    let raw: JSONValue = ["type": "string"]
+    let runtime = try RuntimeComponent(rawSchema: raw)
+    #expect(runtime.parse(.string("abc")).value == .string("abc"))
+  }
+
+  @Test func anyValueInit() {
+    let any = JSONAnyValue(JSONString())
+    #expect(any.schemaValue.object?[Keywords.TypeKeyword.name] == .string("string"))
+  }
+}


### PR DESCRIPTION
## Summary
- rename wrapper types for clarity (`AnySchemaComponent`, `OptionalComponent`, `PassthroughComponent`)
- add `RuntimeComponent` for validating using a runtime `Schema`
- extend `JSONAnyValue` with an initializer for any component
- document wrapper types in DocC and link new article
- show wrappers in new SwiftTesting suite

## Testing
- `swift test -l`
- `swift test`

Closes #51 

------
https://chatgpt.com/codex/tasks/task_e_68445616de74833199ccf52886f51377