### PR TITLE
Add custom schema convertible

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -4,3 +4,4 @@ builder:
     - documentation_targets:
       - JSONSchema
       - JSONSchemaBuilder
+      - JSONSchemaConversion

--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,10 @@ let package = Package(
       name: "JSONSchemaClient",
       targets: ["JSONSchemaClient"]
     ),
+    .library(
+      name: "JSONSchemaConversion",
+      targets: ["JSONSchemaConversion"]
+    ),
   ],
   dependencies: [
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
@@ -101,6 +105,20 @@ let package = Package(
       ],
       exclude: [
         "__Snapshots__"
+      ]
+    ),
+
+    // Library for custom conversions for JSONSchemaBuilder.
+    .target(
+      name: "JSONSchemaConversion",
+      dependencies: [
+        "JSONSchemaBuilder"
+      ]
+    ),
+    .testTarget(
+      name: "JSONSchemaConversionTests",
+      dependencies: [
+        "JSONSchemaConversion"
       ]
     ),
   ]

--- a/Sources/JSONSchemaBuilder/Formattable.swift
+++ b/Sources/JSONSchemaBuilder/Formattable.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public protocol Formattable {
+  associatedtype Output
+
+  @JSONSchemaBuilder
+  var schema: any JSONSchemaComponent<Output> { get }
+}

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent.swift
@@ -51,6 +51,12 @@ extension JSONSchemaComponent {
     } catch {
       throw .decodingFailed(error)
     }
+    return try parseAndValidate(value)
+  }
+
+  public func parseAndValidate(
+    _ value: JSONValue
+  ) throws(ParseAndValidateIssue) -> Output {
     let parsingResult = parse(value)
     let validationResult = definition().validate(value)
     switch (parsingResult, validationResult.isValid) {

--- a/Sources/JSONSchemaBuilder/Macros/CustomSchemaConversion/CustomSchemaConvertible.swift
+++ b/Sources/JSONSchemaBuilder/Macros/CustomSchemaConversion/CustomSchemaConvertible.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public protocol CustomSchemaConvertible {
+  associatedtype Output
+
+  @JSONSchemaBuilder
+  var schema: any JSONSchemaComponent<Output> { get }
+}

--- a/Sources/JSONSchemaBuilder/Macros/SchemaOptions/SchemaOptions.swift
+++ b/Sources/JSONSchemaBuilder/Macros/SchemaOptions/SchemaOptions.swift
@@ -50,4 +50,9 @@ extension SchemaTrait where Self == SchemaOptionsTrait {
   public static func comment(_ value: String) -> SchemaOptionsTrait {
     fatalError(SchemaOptionsTrait.errorMessage)
   }
+
+  public static func customSchema<C: CustomSchemaConvertible>(_ conversion: C) -> SchemaOptionsTrait
+  {
+    fatalError(SchemaOptionsTrait.errorMessage)
+  }
 }

--- a/Sources/JSONSchemaConversion/Conversions++.swift
+++ b/Sources/JSONSchemaConversion/Conversions++.swift
@@ -1,0 +1,12 @@
+import Foundation
+import JSONSchemaBuilder
+
+public enum Conversions {}
+
+extension Conversions {
+  public static let uuid = UUIDConversion()
+  public static let dateTime = DateTimeConversion()
+  public static let date = DateConversion()
+  public static let time = TimeConversion()
+  public static let url = URLConversion()
+}

--- a/Sources/JSONSchemaConversion/DateConversion.swift
+++ b/Sources/JSONSchemaConversion/DateConversion.swift
@@ -1,0 +1,65 @@
+import Foundation
+import JSONSchemaBuilder
+
+/// A conversion for JSON Schema `date-time` format to `Foundation.Date`.
+///
+/// Accepts strings in ISO 8601 date-time format, e.g. "2023-05-01T12:34:56.789Z".
+/// Returns a `Date` if parsing succeeds, otherwise fails validation.
+public struct DateTimeConversion: CustomSchemaConvertible {
+  public typealias Output = Date
+  public var schema: any JSONSchemaComponent<Date> {
+    JSONString()
+      .format("date-time")
+      .compactMap { value in
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: value)
+      }
+  }
+}
+
+/// A conversion for JSON Schema `date` format to `Foundation.Date`.
+///
+/// Accepts strings in the format "yyyy-MM-dd" (e.g. "2023-05-01").
+/// Returns a `Date` if parsing succeeds, otherwise fails validation.
+public struct DateConversion: CustomSchemaConvertible {
+  public typealias Output = Date
+  public var schema: any JSONSchemaComponent<Date> {
+    JSONString()
+      .format("date")
+      .compactMap { value in
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter.date(from: value)
+      }
+  }
+}
+
+/// A conversion for JSON Schema `time` format to `Foundation.DateComponents`.
+///
+/// Accepts strings in the format "hh:mm:ss(.sss)?(Z|+hh:mm)?" (e.g. "12:34:56.789Z").
+/// Returns `DateComponents` if parsing succeeds, otherwise fails validation.
+public struct TimeConversion: CustomSchemaConvertible {
+  public typealias Output = DateComponents
+  public var schema: any JSONSchemaComponent<DateComponents> {
+    JSONString()
+      .format("time")
+      .compactMap { value in
+        // Basic ISO8601 time parsing (hh:mm:ss(.sss)?(Z|+hh:mm)?)
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [
+          .withTime, .withColonSeparatorInTime, .withFractionalSeconds, .withTimeZone,
+        ]
+        if let date = isoFormatter.date(from: "1970-01-01T" + value) {
+          let calendar = Calendar(identifier: .gregorian)
+          return calendar.dateComponents(
+            [.hour, .minute, .second, .nanosecond, .timeZone],
+            from: date
+          )
+        }
+        return nil
+      }
+  }
+}

--- a/Sources/JSONSchemaConversion/URLConversion.swift
+++ b/Sources/JSONSchemaConversion/URLConversion.swift
@@ -1,0 +1,15 @@
+import Foundation
+import JSONSchemaBuilder
+
+/// A conversion for JSON Schema `uri` format to `Foundation.URL`.
+///
+/// Accepts strings that are valid URIs (e.g. "https://example.com").
+/// Returns a `URL` if parsing succeeds, otherwise fails validation.
+public struct URLConversion: CustomSchemaConvertible {
+  public typealias Output = URL
+  public var schema: any JSONSchemaComponent<URL> {
+    JSONString()
+      .format("uri")
+      .compactMap { URL(string: $0) }
+  }
+}

--- a/Sources/JSONSchemaConversion/UUIDConversion.swift
+++ b/Sources/JSONSchemaConversion/UUIDConversion.swift
@@ -1,0 +1,12 @@
+import Foundation
+import JSONSchemaBuilder
+
+public struct UUIDConversion: CustomSchemaConvertible {
+  public typealias Output = UUID
+
+  public var schema: any JSONSchemaComponent<UUID> {
+    JSONString()
+      .format("uuid")
+      .compactMap { UUID(uuidString: $0) }
+  }
+}

--- a/Tests/JSONSchemaConversionTests/ConversionTests.swift
+++ b/Tests/JSONSchemaConversionTests/ConversionTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import JSONSchemaBuilder
+import JSONSchemaConversion
+import Testing
+
+struct ConversionTests {
+  @Test
+  func uuid() throws {
+    let result = try Conversions.uuid.schema.parseAndValidate(
+      "123e4567-e89b-12d3-a456-426614174000"
+    )
+    #expect(result == UUID(uuidString: "123e4567-e89b-12d3-a456-426614174000")!)
+  }
+
+  @Test
+  func dateTime() throws {
+    let result = try Conversions.dateTime.schema.parseAndValidate(
+      "2023-05-01T12:34:56.789Z"
+    )
+    let expected = ISO8601DateFormatter().date(from: "2023-05-01T12:34:56.789Z")!
+    #expect(result == expected)
+  }
+
+  @Test
+  func date() throws {
+    let result = try Conversions.date.schema.parseAndValidate(
+      "2023-05-01"
+    )
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.dateFormat = "yyyy-MM-dd"
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    let expected = formatter.date(from: "2023-05-01")!
+    #expect(result == expected)
+  }
+
+  @Test
+  func time() throws {
+    let result = try Conversions.time.schema.parseAndValidate(
+      "12:34:56.789Z"
+    )
+    let isoFormatter = ISO8601DateFormatter()
+    isoFormatter.formatOptions = [
+      .withTime, .withColonSeparatorInTime, .withFractionalSeconds, .withTimeZone,
+    ]
+    let date = isoFormatter.date(from: "1970-01-01T12:34:56.789Z")!
+    let calendar = Calendar(identifier: .gregorian)
+    let expected = calendar.dateComponents(
+      [.hour, .minute, .second, .nanosecond, .timeZone],
+      from: date
+    )
+    #expect(result == expected)
+  }
+
+  @Test
+  func url() throws {
+    let result = try Conversions.url.schema.parseAndValidate(
+      "https://example.com"
+    )
+    #expect(result == URL(string: "https://example.com"))
+  }
+}


### PR DESCRIPTION
## Description

This pull request introduces a new library, `JSONSchemaConversion`, to support custom JSON Schema conversions, along with its integration into the existing codebase. It includes new protocols, components, and predefined conversions for common formats like UUIDs, dates, and URLs. Additionally, comprehensive tests have been added to validate the functionality of these conversions.

### Library Integration and Setup:

* **Added `JSONSchemaConversion` as a new library and target**: Updated `Package.swift` to include `JSONSchemaConversion` as a library and test target, with dependencies on `JSONSchemaBuilder`. (`[[1]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR29-R32)`, `[[2]](diffhunk://#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR110-R123)`)
* **Updated `.spi.yml`**: Included `JSONSchemaConversion` in the list of documentation targets. (`[.spi.ymlR7](diffhunk://#diff-5ebda4968fa267b5715182dbe59912825960a0c52655551a4f1c022b712ceaaeR7)`)

### Core Features for Custom Schema Conversion:

* **Introduced `CustomSchemaConvertible` protocol**: Added a protocol to define custom schema conversions using the `@JSONSchemaBuilder` attribute. (`[Sources/JSONSchemaBuilder/Macros/CustomSchemaConversion/CustomSchemaConvertible.swiftR1-R8](diffhunk://#diff-2f57d8755e425e0ebfe904191985a69ae6fb0ef08c274ddcf3bf9a8677e73008R1-R8)`)
* **Predefined conversions**: Implemented conversions for UUIDs, ISO 8601 date-time, dates, times, and URLs using the `CustomSchemaConvertible` protocol. (`[[1]](diffhunk://#diff-63e8bee091528c1d83b03c7099eedd98f189800870baa031088163e4ea8bb10eR1-R12)`, `[[2]](diffhunk://#diff-b178280c5c1419d6579deb8040f7b3b2b6fb7374f8d8d67207b4e6baba269f26R1-R65)`, `[[3]](diffhunk://#diff-d0da2bf06d57cb8c59a962623326d1c46cc5a53dd221e46ddf40b423b62cc503R1-R15)`, `[[4]](diffhunk://#diff-c4bf5649fb73882e8a84584c5a9659652a24e1949853311282403f390b344c39R1-R12)`)

### Enhancements to JSON Schema Builder:

* **Added `Formattable` protocol**: Introduced a protocol for components that can define a schema with a specific output type. (`[Sources/JSONSchemaBuilder/Formattable.swiftR1-R8](diffhunk://#diff-d00caedfbf262f3d64d785c9688ca49351979f55289094419cc30d4ad101771fR1-R8)`)
* **New `parseAndValidate` method**: Extended `JSONSchemaComponent` to include a method for parsing and validating JSON values in a single operation. (`[Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent.swiftR54-R59](diffhunk://#diff-a8b1edee6e07026db8c1b5c9a548d670a407736bcc17f40ea86670343287af1aR54-R59)`)
* **Custom schema option**: Added support for custom schema conversion in `SchemaOptionsTrait`. (`[Sources/JSONSchemaBuilder/Macros/SchemaOptions/SchemaOptions.swiftR53-R57](diffhunk://#diff-09e512ba161af09678a60abe307cf569c6f61695f426ecd09af3c906d6118ab4R53-R57)`)

### Testing:

* **Comprehensive tests for conversions**: Added test cases in `ConversionTests.swift` to validate the behavior of UUID, date-time, date, time, and URL conversions. (`[Tests/JSONSchemaConversionTests/ConversionTests.swiftR1-R62](diffhunk://#diff-e231990922e95e5cd615718a5e6a8c63ffa22a69163574ad02779cdd4b02b3aaR1-R62)`)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.
