### PR TITLE
Adds constant builder

### DIFF
--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Constant.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/Constant.swift
@@ -1,0 +1,9 @@
+import JSONSchema
+
+extension JSONSchemaComponent {
+  public func constant(_ value: JSONValue) -> Self {
+    var copy = self
+    copy.schemaValue[Keywords.Constant.name] = value
+    return copy
+  }
+}

--- a/Tests/JSONSchemaBuilderTests/JSONModifierTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONModifierTests.swift
@@ -1,6 +1,6 @@
 import JSONSchema
-import Testing
 import JSONSchemaBuilder
+import Testing
 
 struct JSONEnumTests {
   @Test func singleValue() {
@@ -75,8 +75,6 @@ struct JSONEnumTests {
   }
 }
 
-
-
 struct JSONConstantTests {
   @Test func constantOnly() {
     @JSONSchemaBuilder var sample: some JSONSchemaComponent {
@@ -85,7 +83,7 @@ struct JSONConstantTests {
     }
 
     let expected: [String: JSONValue] = [
-      "const": "red",
+      "const": "red"
     ]
 
     #expect(sample.schemaValue == .object(expected))

--- a/Tests/JSONSchemaBuilderTests/JSONModifierTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONModifierTests.swift
@@ -1,7 +1,6 @@
 import JSONSchema
 import Testing
-
-@testable import JSONSchemaBuilder
+import JSONSchemaBuilder
 
 struct JSONEnumTests {
   @Test func singleValue() {
@@ -70,6 +69,37 @@ struct JSONEnumTests {
       "title": "Color",
       "type": "string",
       "enum": ["red", "amber", "green"],
+    ]
+
+    #expect(sample.schemaValue == .object(expected))
+  }
+}
+
+
+
+struct JSONConstantTests {
+  @Test func constantOnly() {
+    @JSONSchemaBuilder var sample: some JSONSchemaComponent {
+      JSONAnyValue()
+        .constant("red")
+    }
+
+    let expected: [String: JSONValue] = [
+      "const": "red",
+    ]
+
+    #expect(sample.schemaValue == .object(expected))
+  }
+
+  @Test func string() {
+    @JSONSchemaBuilder var sample: some JSONSchemaComponent {
+      JSONString()
+        .constant("red")
+    }
+
+    let expected: [String: JSONValue] = [
+      "type": "string",
+      "const": "red",
     ]
 
     #expect(sample.schemaValue == .object(expected))


### PR DESCRIPTION
## Description

Adds a `.constant(JSONValue)` modifier

```swift
   @JSONSchemaBuilder var sample: some JSONSchemaComponent {
      JSONString()
        .constant("red")
    }
```

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.
