### PR TITLE
Fix group merge with JSONSchema

### DIFF
--- a/Sources/JSONSchema/JSONValue/JSONValue+merge.swift
+++ b/Sources/JSONSchema/JSONValue/JSONValue+merge.swift
@@ -1,0 +1,31 @@
+extension JSONValue {
+  /// Mutates `self` by merging in values from `other`.
+  /// - Arrays are concatenated.
+  /// - Objects are merged recursively.
+  /// - Scalars are preserved unless `self` is `.null`.
+  public mutating func merge(_ other: JSONValue) {
+    switch (self, other) {
+    case (.object(var lhsDict), .object(let rhsDict)):
+      for (key, rhsValue) in rhsDict {
+        if let lhsValue = lhsDict[key] {
+          var mergedValue = lhsValue
+          mergedValue.merge(rhsValue)
+          lhsDict[key] = mergedValue
+        } else {
+          lhsDict[key] = rhsValue
+        }
+      }
+      self = .object(lhsDict)
+
+    case (.array(let lhsArray), .array(let rhsArray)):
+      self = .array(lhsArray + rhsArray)
+
+    case (.null, let rhs):  // If self is null, adopt other
+      self = rhs
+
+    default:
+      // Keep existing self by default (no overwrite)
+      break
+    }
+  }
+}

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchema.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchema.swift
@@ -24,14 +24,20 @@ public struct JSONSchema<Components: JSONSchemaComponent, NewOutput>: JSONSchema
     self.components = component()
   }
 
-  /// Creates a new schema component.
-  /// - Parameter component: The components to group together.
-  public init(@JSONSchemaBuilder component: () -> Components) where Components.Output == NewOutput {
-    self.transform = { $0 }
-    self.components = component()
-  }
-
   public func parse(_ value: JSONValue) -> Parsed<NewOutput, ParseIssue> {
     components.parse(value).map(transform)
+  }
+}
+
+extension JSONSchema where NewOutput == JSONValue, Components == JSONComponents.MergedComponent {
+  /// Creates a new schema component.
+  /// - Parameter components: The components to group together.
+  public init(
+    @JSONSchemaCollectionBuilder<JSONValue> components: () -> [JSONComponents.AnySchemaComponent<
+      JSONValue
+    >]
+  ) {
+    self.transform = { $0 }
+    self.components = JSONComponents.MergedComponent(components: components())
   }
 }

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/MergedComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/MergedComponent.swift
@@ -1,0 +1,46 @@
+import JSONSchema
+
+extension JSONSchemaComponent {
+  public func merging<C: JSONSchemaComponent>(with other: C) -> JSONComponents.MergedComponent
+  where Self.Output == JSONValue, C.Output == JSONValue {
+    JSONComponents.MergedComponent(components: [
+      JSONComponents.AnySchemaComponent(self),
+      JSONComponents.AnySchemaComponent(other),
+    ])
+  }
+}
+
+extension JSONComponents {
+  public struct MergedComponent: JSONSchemaComponent {
+    public var schemaValue: SchemaValue {
+      get {
+        components.reduce(into: SchemaValue.object([:])) { result, component in
+          result.merge(component.schemaValue)
+        }
+      }
+      set {}
+    }
+
+    let components: [JSONComponents.AnySchemaComponent<JSONValue>]
+
+    public init(components: [JSONComponents.AnySchemaComponent<JSONValue>]) {
+      self.components = components
+    }
+
+    public func parse(_ value: JSONValue) -> Parsed<JSONValue, ParseIssue> {
+      var errors: [ParseIssue] = []
+      for component in components {
+        switch component.parse(value) {
+        case .valid:
+          continue
+        case .invalid(let errs):
+          errors.append(contentsOf: errs)
+        }
+      }
+      guard errors.isEmpty else {
+        return .invalid(errors)
+      }
+      return .valid(value)
+    }
+  }
+}

--- a/Sources/JSONSchemaBuilder/JSONComponent/SchemaValue.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/SchemaValue.swift
@@ -48,8 +48,18 @@ public enum SchemaValue: Sendable, Equatable {
       self = .object(dict)
     case (.object(let dict), .boolean):
       self = .object(dict)
-    case (.object(let dict1), .object(let dict2)):
-      self = .object(dict1.merging(dict2) { current, _ in current })
+    case (.object(var dict1), .object(let dict2)):
+      for (key, value2) in dict2 {
+        if let value1 = dict1[key] {
+          // If both values are objects, merge recursively
+          var merged = value1
+          merged.merge(value2)
+          dict1[key] = merged
+        } else {
+          dict1[key] = value2
+        }
+      }
+      self = .object(dict1)
     }
   }
 }

--- a/Tests/JSONSchemaBuilderTests/JSONSchemaTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONSchemaTests.swift
@@ -342,3 +342,34 @@ struct JSONAdvancedBuilderTests {
     #expect(sample.schemaValue == .object(expected))
   }
 }
+
+struct JSONSchemaGroupTests {
+  @Test func group() {
+    let message = JSONObject {
+      JSONProperty(key: "to") { JSONString() }
+      JSONProperty(key: "from") { JSONString() }
+    }
+
+    let typeExtension = JSONObject {
+      JSONProperty(key: "type") {
+        JSONAnyValue().constant("message")
+      }
+    }
+
+    let fullMessage = JSONSchema {
+      message
+      typeExtension
+    }
+
+    let expected: [String: JSONValue] = [
+      "type": "object",
+      "properties": [
+        "to": ["type": "string"],
+        "from": ["type": "string"],
+        "type": ["const": "message"],
+      ],
+    ]
+
+    #expect(fullMessage.schemaValue == .object(expected))
+  }
+}

--- a/Tests/JSONSchemaTests/JSONValueTests.swift
+++ b/Tests/JSONSchemaTests/JSONValueTests.swift
@@ -12,4 +12,82 @@ struct JSONValueTests {
     let jsonValue = try JSONDecoder().decode(JSONValue.self, from: jsonString.data(using: .utf8)!)
     #expect(jsonValue == ["const": .null])
   }
+
+  @Test
+  func mergeObjects() {
+    var a: JSONValue = .object([
+      "type": .string("object"),
+      "properties": .object([
+        "to": .object(["type": .string("string")])
+      ]),
+    ])
+
+    let b: JSONValue = .object([
+      "properties": .object([
+        "from": .object(["type": .string("string")])
+      ])
+    ])
+
+    a.merge(b)
+
+    #expect(a.object?["type"] == .string("object"))
+    #expect(a.object?["properties"]?.object?.count == 2)
+    #expect(a.object?["properties"]?.object?["to"] != nil)
+    #expect(a.object?["properties"]?.object?["from"] != nil)
+  }
+
+  @Test
+  func mergeArrays() {
+    var a: JSONValue = .array([.string("a")])
+    let b: JSONValue = .array([.string("b"), .string("c")])
+
+    a.merge(b)
+
+    #expect(a == .array([.string("a"), .string("b"), .string("c")]))
+  }
+
+  @Test
+  func mergeScalarPreserve() {
+    var a: JSONValue = .string("keep me")
+    let b: JSONValue = .string("overwrite me")
+
+    a.merge(b)
+
+    #expect(a == .string("keep me"))  // scalar is preserved
+  }
+
+  @Test
+  func mergeNullGetsOverwritten() {
+    var a: JSONValue = .null
+    let b: JSONValue = .boolean(true)
+
+    a.merge(b)
+
+    #expect(a == .boolean(true))
+  }
+
+  @Test
+  func deeplyNestedMerge() {
+    var a: JSONValue = .object([
+      "outer": .object([
+        "inner": .object([
+          "a": .string("a")
+        ])
+      ])
+    ])
+
+    let b: JSONValue = .object([
+      "outer": .object([
+        "inner": .object([
+          "b": .string("b")
+        ])
+      ])
+    ])
+
+    a.merge(b)
+
+    let inner = a.object?["outer"]?.object?["inner"]?.object
+    #expect(inner?["a"] == .string("a"))
+    #expect(inner?["b"] == .string("b"))
+  }
 }


### PR DESCRIPTION
## Description

Fixes merging behavior and unlocks the ability to merge JSONSchemaComponents. It does drop the strongly typed parse information though.

```swift
let message = JSONObject {
      JSONProperty(key: "to") { JSONString() }
      JSONProperty(key: "from") { JSONString() }
    }

    let typeExtension = JSONObject {
      JSONProperty(key: "type") {
        JSONAnyValue().constant("message")
      }
    }

    let fullMessage = JSONSchema {
      message
      typeExtension
    }
```

JSON Schema:
```json
{
      "type": "object",
      "properties": {
        "to": { "type": "string" },
        "from": { "type": "string" },
        "type": { "const": "message" },
      }
}
```

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.
