### PR TITLE
Support loops and conditionals in JSONSchemaCollectionBuilder

### DIFF
--- a/Sources/JSONSchemaBuilder/Builders/JSONSchemaBuilder.swift
+++ b/Sources/JSONSchemaBuilder/Builders/JSONSchemaBuilder.swift
@@ -50,6 +50,37 @@ import JSONSchema
   ) -> [JSONComponents.AnySchemaComponent<Output>] where Component.Output == Output {
     accumulated + [component.eraseToAnySchemaComponent()]
   }
+
+  public static func buildPartialBlock(
+    first components: [JSONComponents.AnySchemaComponent<Output>]
+  ) -> [JSONComponents.AnySchemaComponent<Output>] { components }
+
+  public static func buildPartialBlock(
+    accumulated: [JSONComponents.AnySchemaComponent<Output>],
+    next components: [JSONComponents.AnySchemaComponent<Output>]
+  ) -> [JSONComponents.AnySchemaComponent<Output>] {
+    accumulated + components
+  }
+
+  public static func buildOptional(
+    _ component: [JSONComponents.AnySchemaComponent<Output>]?
+  ) -> [JSONComponents.AnySchemaComponent<Output>] {
+    component ?? []
+  }
+
+  public static func buildEither(
+    first component: [JSONComponents.AnySchemaComponent<Output>]
+  ) -> [JSONComponents.AnySchemaComponent<Output>] { component }
+
+  public static func buildEither(
+    second component: [JSONComponents.AnySchemaComponent<Output>]
+  ) -> [JSONComponents.AnySchemaComponent<Output>] { component }
+
+  public static func buildArray(
+    _ components: [[JSONComponents.AnySchemaComponent<Output>]]
+  ) -> [JSONComponents.AnySchemaComponent<Output>] {
+    components.flatMap { $0 }
+  }
 }
 
 extension JSONSchemaCollectionBuilder where Output == JSONValue {

--- a/Tests/JSONSchemaBuilderTests/JSONCompositionTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONCompositionTests.swift
@@ -90,4 +90,32 @@ struct JSONCompositionTests {
 
     #expect(sample.schemaValue == .object(expected))
   }
+
+  @Test func forLoop() {
+    @JSONSchemaBuilder var sample: some JSONSchemaComponent {
+      JSONComposition.AllOf {
+        for i in 0..<10 {
+          JSONString()
+            .title("\(i)")
+        }
+      }
+    }
+
+    #expect(sample.schemaValue.object?[Keywords.AllOf.name]?.array?.count == 10)
+  }
+
+  @Test(arguments: [true, false]) func `if`(bool: Bool) {
+    @JSONSchemaBuilder var sample: some JSONSchemaComponent {
+      JSONComposition.AllOf {
+        if bool {
+          JSONString()
+            .title("0")
+        }
+      }
+    }
+
+    #expect(
+      sample.schemaValue.object?[Keywords.AllOf.name]?.array?.count == (bool ? 1 : 0)
+    )
+  }
 }

--- a/Tests/JSONSchemaBuilderTests/JSONCompositionTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONCompositionTests.swift
@@ -94,7 +94,7 @@ struct JSONCompositionTests {
   @Test func forLoop() {
     @JSONSchemaBuilder var sample: some JSONSchemaComponent {
       JSONComposition.AllOf {
-        for i in 0..<10 {
+        for i in 0 ..< 10 {
           JSONString()
             .title("\(i)")
         }


### PR DESCRIPTION
## Description

This pull request enhances the functionality of the `JSONSchemaBuilder` module by introducing new methods to support advanced schema building patterns and adds corresponding tests to validate these features. The changes focus on improving composability and flexibility in JSON schema construction.

### Enhancements to JSON schema building:

* [`Sources/JSONSchemaBuilder/Builders/JSONSchemaBuilder.swift`](diffhunk://#diff-aeaf52ac3764986031af98121a0d25a5628678d31a3a08ea6bf0fea8786f4e56R53-R83): Added several new static methods (`buildPartialBlock`, `buildOptional`, `buildEither`, and `buildArray`) to the `JSONSchemaCollectionBuilder` type, enabling support for conditional, optional, and array-based schema components. These methods enhance the composability of schema definitions.

### Addition of tests for new schema building features:

* [`Tests/JSONSchemaBuilderTests/JSONCompositionTests.swift`](diffhunk://#diff-76968edf7824305e978374ecb85305e63f5b1cf70fe0fe3f1ae108078a909e66R93-R120): Added tests for `for` loops and `if` conditions within schema definitions using the `@JSONSchemaBuilder` property wrapper. These tests validate the correct behavior of the new composability features, ensuring they handle dynamic and conditional schema generation as expected.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.
