### PR TITLE
Add content media type helpers

### DIFF
--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent+Content.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent+Content.swift
@@ -1,0 +1,21 @@
+import JSONSchema
+
+extension JSONSchemaComponent {
+  /// Specifies the encoding used to represent non-JSON data.
+  /// - Parameter value: The content encoding (e.g. "base64").
+  /// - Returns: A new instance with the `contentEncoding` keyword set.
+  public func contentEncoding(_ value: String) -> Self {
+    var copy = self
+    copy.schemaValue[Keywords.ContentEncoding.name] = .string(value)
+    return copy
+  }
+
+  /// Specifies the media type of the decoded content.
+  /// - Parameter value: The media type (e.g. "image/png").
+  /// - Returns: A new instance with the `contentMediaType` keyword set.
+  public func contentMediaType(_ value: String) -> Self {
+    var copy = self
+    copy.schemaValue[Keywords.ContentMediaType.name] = .string(value)
+    return copy
+  }
+}

--- a/Tests/JSONSchemaBuilderTests/ContentMediaTypeTests.swift
+++ b/Tests/JSONSchemaBuilderTests/ContentMediaTypeTests.swift
@@ -1,0 +1,22 @@
+import JSONSchema
+import Testing
+
+@testable import JSONSchemaBuilder
+
+struct ContentMediaTypeBuilderTests {
+  @Test func encodingAndMediaType() {
+    @JSONSchemaBuilder var sample: some JSONSchemaComponent<String> {
+      JSONString()
+        .contentEncoding("base64")
+        .contentMediaType("image/png")
+    }
+
+    let expected: [String: JSONValue] = [
+      "type": "string",
+      "contentEncoding": "base64",
+      "contentMediaType": "image/png",
+    ]
+
+    #expect(sample.schemaValue == .object(expected))
+  }
+}


### PR DESCRIPTION
## Summary
- add `.contentEncoding` and `.contentMediaType` helpers
- cover builder for media type keywords with tests

## Testing
- `make format`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_686316a6fabc8331a0eb3690771efc93