### PR TITLE
Add capture support for propertyNames

### DIFF
--- a/Sources/JSONSchemaBuilder/Documentation.docc/Articles/WrapperTypes.md
+++ b/Sources/JSONSchemaBuilder/Documentation.docc/Articles/WrapperTypes.md
@@ -12,6 +12,7 @@ The builder provides several wrappers that can modify or combine components.
 | ``JSONComponents/PassthroughComponent`` | Validates with a wrapped component but returns the original input value. |
 | ``JSONComponents/AdditionalProperties`` | Adds ``additionalProperties`` validation for objects. |
 | ``JSONComponents/PatternProperties`` | Adds ``patternProperties`` validation for objects. |
+| ``JSONComponents/PropertyNames`` | Validates and captures property names for objects. |
 | ``JSONComponents/Conditional`` | Stores either of two components for ``buildEither`` cases. |
 | ``JSONComposition`` wrappers | ``AnyOf``/``AllOf``/``OneOf``/``Not`` compose multiple schemas. |
 | ``JSONSchema`` | Groups several components together and optionally maps them to a new type. |

--- a/Sources/JSONSchemaBuilder/Documentation.docc/JSONSchemaBuilder.md
+++ b/Sources/JSONSchemaBuilder/Documentation.docc/JSONSchemaBuilder.md
@@ -100,6 +100,23 @@ The third example will validate that:
 - The `name` property is a string
 - Any additional properties must be numbers greater than or equal to 0
 
+### Property Names
+
+The ``JSONObject/propertyNames(_:)`` modifier validates each property name using a subschema and captures the ones that match. The captured result is provided as a ``CapturedPropertyNames`` value containing the names seen, their raw strings, and an optional whitelist derived from ``enum`` values.
+
+```swift
+enum Emotion: String, CaseIterable { case happy, sad, angry }
+
+@JSONSchemaBuilder var schema: some JSONSchemaComponent<((), CapturedPropertyNames<Emotion>)> {
+  JSONObject()
+    .propertyNames {
+      JSONString()
+        .enumValues { Emotion.allCases.map(\.rawValue) }
+        .compactMap(Emotion.init(rawValue:))
+    }
+}
+```
+
 ## Topics
 
 - <doc:Macros>

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/PropertyNames.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/PropertyNames.swift
@@ -6,13 +6,10 @@ public struct CapturedPropertyNames<Name: Hashable> {
   public var seen: [Name]
   /// The original string keys from the instance.
   public var raw: [String]
-  /// Optional whitelist of allowed names if provided by the schema via `enum`.
-  public var allowed: Set<Name>?
 
-  public init(seen: [Name] = [], raw: [String] = [], allowed: Set<Name>? = nil) {
+  public init(seen: [Name] = [], raw: [String] = []) {
     self.seen = seen
     self.raw = raw
-    self.allowed = allowed
   }
 }
 
@@ -56,21 +53,7 @@ extension JSONComponents {
         }
       }
 
-      var allowed: Set<Names.Output>? = nil
-      if let enumValues = propertyNamesSchema.schemaValue[Keywords.Enum.name]?.array {
-        var set = Set<Names.Output>()
-        for value in enumValues {
-          switch propertyNamesSchema.parse(value) {
-          case .valid(let name):
-            set.insert(name)
-          case .invalid:
-            continue
-          }
-        }
-        allowed = set
-      }
-
-      let capture = CapturedPropertyNames(seen: seen, raw: raw, allowed: allowed)
+      let capture = CapturedPropertyNames(seen: seen, raw: raw)
 
       switch baseResult {
       case .valid(let baseOut):

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/PropertyNames.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/PropertyNames.swift
@@ -97,4 +97,3 @@ extension JSONSchemaComponent {
     )
   }
 }
-

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONObject.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONObject.swift
@@ -103,18 +103,6 @@ extension JSONSchemaComponent {
     return copy
   }
 
-  /// Adds schema options to validate property names against.
-  /// The content should be a ``JSONString`` to produce a valid schema.
-  /// - Parameter content: A string schema component.
-  /// - Returns: A new `JSONObject` with the property names set.
-  public func propertyNames<C: JSONSchemaComponent>(
-    @JSONSchemaBuilder _ content: () -> C
-  ) -> Self {
-    var copy = self
-    copy.schemaValue[Keywords.PropertyNames.name] = content().schemaValue.value
-    return copy
-  }
-
   /// Adds a minimum number of properties constraint to the schema.
   /// - Parameter value: The minimum number of properties that the object must have.
   /// - Returns: A new `JSONObject` with the min properties constraint set.

--- a/Sources/JSONSchemaClient/main.swift
+++ b/Sources/JSONSchemaClient/main.swift
@@ -179,3 +179,11 @@ struct AutoAntherTestPerson {
   let emotions: [String: Int]
   let analysisNotes: String
 }
+
+@Schemable
+enum UserProfileSetting {
+  case username(String)
+  case age(Int)
+  case preferredLanguages([String])
+  case contactInfo([String: String])
+}

--- a/Sources/JSONSchemaClient/main.swift
+++ b/Sources/JSONSchemaClient/main.swift
@@ -131,3 +131,51 @@ do {
 } catch {
   dump(error)
 }
+
+@Schemable
+enum TestEmotion: String {
+  case happy
+  case sad
+  case angry
+  case neutral
+  case nurturantLove
+}
+
+@Schemable
+struct TestPerson {
+  let emotions: [TestEmotion: Int]
+  let analysisNotes: String
+}
+
+printSchema(TestPerson.schema)
+
+//@Schemable
+struct AntherTestPerson: Schemable {
+  let emotions: [String: Int]
+  let analysisNotes: String
+
+  static var schema: some JSONSchemaComponent<AntherTestPerson> {
+    JSONSchema(AntherTestPerson.init) {
+      JSONObject {
+        JSONProperty(key: "emotions") {
+          JSONObject()
+            .additionalProperties {
+              JSONInteger()
+            }
+            .map(\.1.matches)
+        }
+        .required()
+        JSONProperty(key: "analysisNotes") {
+          JSONString()
+        }
+        .required()
+      }
+    }
+  }
+}
+
+@Schemable
+struct AutoAntherTestPerson {
+  let emotions: [String: Int]
+  let analysisNotes: String
+}

--- a/Sources/JSONSchemaMacro/Schemable/SchemaOptionsGenerator.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SchemaOptionsGenerator.swift
@@ -71,7 +71,7 @@ enum SchemaOptionsGenerator {
       }
       // Intentionally fall through to "patternProperties" to handle shared logic.
       fallthrough
-    case "patternProperties":
+    case "patternProperties", "propertyNames":
       return """
         \(codeBlockItem)
         .\(raw: optionName) { \(closure.statements) }

--- a/Sources/JSONSchemaMacro/Schemable/SwiftSyntaxExtensions.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SwiftSyntaxExtensions.swift
@@ -49,11 +49,9 @@ extension TypeSyntax {
       case .primitive(let primitive, _):
         guard primitive == .string else { return .notSupported }
 
-        // Only add .map(\.matches) for schemable types (custom types), not for primitives
         let mapMatches =
           switch valueTypeInfo {
-          case .schemable: "\n.map(\\.matches)"
-          case .primitive: ""
+          case .schemable, .primitive: "\n.map(\\.matches)"
           case .notSupported: ""
           }
 
@@ -87,7 +85,7 @@ extension TypeSyntax {
             """
         )
 
-      case .primitive, .notSupported:
+      case .notSupported:
         return .notSupported
       }
     case .identifierType(let identifierType):

--- a/Sources/JSONSchemaMacro/Schemable/SwiftSyntaxExtensions.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SwiftSyntaxExtensions.swift
@@ -76,10 +76,15 @@ extension TypeSyntax {
               \(valueCodeBlock)
             }
             .map { value in
-              Dictionary(
-                uniqueKeysWithValues: zip(value.0.1.seen, value.0.1.raw).compactMap { seen, raw in
-                  value.1.matches[raw].map { (seen, $0) }
-                }
+              let (_, capturedNames) = value.0
+              let additionalProperties = value.1
+              return Dictionary(
+                uniqueKeysWithValues: zip(capturedNames.seen, capturedNames.raw)
+                  .compactMap { parsedKey, rawKey in
+                    additionalProperties.matches[rawKey].map { parsedValue in
+                      (parsedKey, parsedValue)
+                    }
+                  }
               )
             }
             """

--- a/Tests/JSONSchemaBuilderTests/JSONSchemaTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONSchemaTests.swift
@@ -8,8 +8,10 @@ struct JSONSchemaOptionBuilderTests {
     @JSONSchemaBuilder var sample:
       some JSONSchemaComponent<
         (
-          (((String?, String, Bool?, Double), PatternPropertiesParseResult<String?>),
-            CapturedPropertyNames<String>),
+          (
+            ((String?, String, Bool?, Double), PatternPropertiesParseResult<String?>),
+            CapturedPropertyNames<String>
+          ),
           AdditionalPropertiesParseResult<Bool>
         )
       >

--- a/Tests/JSONSchemaBuilderTests/JSONSchemaTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONSchemaTests.swift
@@ -8,7 +8,8 @@ struct JSONSchemaOptionBuilderTests {
     @JSONSchemaBuilder var sample:
       some JSONSchemaComponent<
         (
-          ((String?, String, Bool?, Double), PatternPropertiesParseResult<String?>),
+          (((String?, String, Bool?, Double), PatternPropertiesParseResult<String?>),
+            CapturedPropertyNames<String>),
           AdditionalPropertiesParseResult<Bool>
         )
       >

--- a/Tests/JSONSchemaBuilderTests/ParsingTests.swift
+++ b/Tests/JSONSchemaBuilderTests/ParsingTests.swift
@@ -74,7 +74,6 @@ struct ParsingTests {
     case .valid((_, let names)):
       #expect(Set(names.seen) == Set([.happy, .sad]))
       #expect(Set(names.raw) == Set(["happy", "sad"]))
-      #expect(names.allowed == Set(Emotion.allCases))
     default:
       #expect(Bool(false), "Expected valid parse result with propertyNames capture")
     }

--- a/Tests/JSONSchemaBuilderTests/ParsingTests.swift
+++ b/Tests/JSONSchemaBuilderTests/ParsingTests.swift
@@ -54,9 +54,7 @@ struct ParsingTests {
   @Test func propertyNamesCapture() throws {
     enum Emotion: String, CaseIterable { case happy, sad, angry }
 
-    @JSONSchemaBuilder var sample:
-      some JSONSchemaComponent<((), CapturedPropertyNames<Emotion>)>
-    {
+    @JSONSchemaBuilder var sample: some JSONSchemaComponent<((), CapturedPropertyNames<Emotion>)> {
       JSONObject()
         .propertyNames {
           JSONString()

--- a/Tests/JSONSchemaBuilderTests/ParsingTests.swift
+++ b/Tests/JSONSchemaBuilderTests/ParsingTests.swift
@@ -3,6 +3,11 @@ import JSONSchemaBuilder
 import Testing
 
 struct ParsingTests {
+  @Schemable enum TestEmotion: String { case happy, sad, angry }
+  @Schemable struct TestPerson {
+    let emotions: [TestEmotion: Int]
+    let analysisNotes: String
+  }
   @Test func patternProperties() throws {
     @JSONSchemaBuilder var sample:
       some JSONSchemaComponent<((), PatternPropertiesParseResult<String?>)>
@@ -44,6 +49,37 @@ struct ParsingTests {
     let result = sample.parse(input)
 
     #expect(result.value?.1.matches.count == 3)
+  }
+
+  @Test func propertyNamesCapture() throws {
+    enum Emotion: String, CaseIterable { case happy, sad, angry }
+
+    @JSONSchemaBuilder var sample:
+      some JSONSchemaComponent<((), CapturedPropertyNames<Emotion>)>
+    {
+      JSONObject()
+        .propertyNames {
+          JSONString()
+            .enumValues { Emotion.allCases.map(\.rawValue) }
+            .compactMap(Emotion.init(rawValue:))
+        }
+    }
+
+    let input: JSONValue = [
+      "happy": true,
+      "sad": false,
+    ]
+
+    let result = sample.parse(input)
+
+    switch result {
+    case .valid((_, let names)):
+      #expect(Set(names.seen) == Set([.happy, .sad]))
+      #expect(Set(names.raw) == Set(["happy", "sad"]))
+      #expect(names.allowed == Set(Emotion.allCases))
+    default:
+      #expect(Bool(false), "Expected valid parse result with propertyNames capture")
+    }
   }
 
   @Test func patternAndAdditionalProperties() throws {
@@ -93,5 +129,18 @@ struct ParsingTests {
     #expect(throws: ParseAndValidateIssue.self) {
       _ = try sample.parseAndValidate(instance: "{\"extra\": true}")
     }
+  }
+
+  @Test func dictionaryWithEnumKeysParsing() throws {
+    let input: JSONValue = [
+      "emotions": ["happy": 1, "sad": 2],
+      "analysisNotes": "hi",
+    ]
+
+    let result = TestPerson.schema.parse(input)
+    let person = try #require(result.value)
+    #expect(person.emotions[.happy] == 1)
+    #expect(person.emotions[.sad] == 2)
+    #expect(person.analysisNotes == "hi")
   }
 }

--- a/Tests/JSONSchemaIntegrationTests/DictionaryArrayIntegrationTests.swift
+++ b/Tests/JSONSchemaIntegrationTests/DictionaryArrayIntegrationTests.swift
@@ -1,0 +1,422 @@
+import JSONSchema
+import JSONSchemaBuilder
+import Testing
+
+
+@Schemable
+enum Emotion {
+  case happy
+  case sad
+  case excited
+  case calm
+  case anxious
+}
+
+@Schemable
+enum Priority {
+  case low
+  case medium
+  case high
+  case critical
+}
+
+@Schemable
+struct Task {
+  /// Unique identifier for the task
+  @SchemaOptions(.description("Unique identifier for the task"))
+  let id: String
+  
+  /// Title of the task
+  @StringOptions(.minLength(1), .maxLength(100))
+  let title: String
+  
+  /// Detailed description of the task
+  @StringOptions(.maxLength(500))
+  let description: String?
+  
+  /// Priority level of the task
+  let priority: Priority
+  
+  /// Whether the task is completed
+  let isCompleted: Bool
+  
+  /// Tags associated with the task
+  @ArrayOptions(.minItems(0), .maxItems(10))
+  let tags: [String]
+  
+  /// Emotional state while working on the task
+  let emotionalState: Emotion?
+  
+  /// When the task was created
+  @StringOptions(.format("date-time"))
+  let createdAt: String
+  
+  /// When the task is due
+  @StringOptions(.format("date-time"))
+  let dueDate: String?
+}
+
+@Schemable
+struct Project {
+  /// Unique identifier for the project
+  let id: String
+  
+  /// Name of the project
+  @StringOptions(.minLength(1), .maxLength(200))
+  let name: String
+  
+  /// Project description
+  @StringOptions(.maxLength(1000))
+  let description: String?
+  
+  /// Tasks organized by priority
+  let tasksByPriority: [Priority: [Task]]
+  
+  /// Tasks organized by emotional state
+  let tasksByEmotion: [Emotion: [Task]]
+  
+  /// General project metadata
+  let metadata: [String: String]
+  
+  /// Project statistics
+  let stats: [String: Int]
+  
+  /// Project team members
+  @ArrayOptions(.minItems(1))
+  let teamMembers: [String]
+  
+  /// Project milestones
+  @ArrayOptions(.minItems(0))
+  let milestones: [String]
+  
+  /// When the project was created
+  @StringOptions(.format("date-time"))
+  let createdAt: String
+  
+  /// Project status
+  let status: ProjectStatus
+}
+
+@Schemable
+enum ProjectStatus {
+  case planning
+  case active
+  case onHold
+  case completed
+  case cancelled
+}
+
+// MARK: - Integration Tests
+
+struct DictionaryArrayIntegrationTests {
+  @Test
+  func testValidProjectWithComplexDictionaries() throws {
+    let json = """
+    {
+      "id": "proj-001",
+      "name": "AI-Powered Task Manager",
+      "description": "A sophisticated task management system with emotional intelligence",
+      "tasksByPriority": {
+        "high": [
+          {
+            "id": "task-001",
+            "title": "Design Core Architecture",
+            "description": "Create the foundational system design",
+            "priority": "high",
+            "isCompleted": false,
+            "tags": ["architecture", "design"],
+            "emotionalState": "excited",
+            "createdAt": "2024-01-15T09:00:00Z",
+            "dueDate": "2024-01-22T17:00:00Z"
+          }
+        ],
+        "medium": [
+          {
+            "id": "task-002",
+            "title": "Write Documentation",
+            "description": "Document the API endpoints",
+            "priority": "medium",
+            "isCompleted": true,
+            "tags": ["documentation", "api"],
+            "emotionalState": "calm",
+            "createdAt": "2024-01-10T14:00:00Z",
+            "dueDate": "2024-01-17T17:00:00Z"
+          }
+        ]
+      },
+      "tasksByEmotion": {
+        "excited": [
+          {
+            "id": "task-001",
+            "title": "Design Core Architecture",
+            "description": "Create the foundational system design",
+            "priority": "high",
+            "isCompleted": false,
+            "tags": ["architecture", "design"],
+            "emotionalState": "excited",
+            "createdAt": "2024-01-15T09:00:00Z",
+            "dueDate": "2024-01-22T17:00:00Z"
+          }
+        ],
+        "calm": [
+          {
+            "id": "task-002",
+            "title": "Write Documentation",
+            "description": "Document the API endpoints",
+            "priority": "medium",
+            "isCompleted": true,
+            "tags": ["documentation", "api"],
+            "emotionalState": "calm",
+            "createdAt": "2024-01-10T14:00:00Z",
+            "dueDate": "2024-01-17T17:00:00Z"
+          }
+        ]
+      },
+      "metadata": {
+        "department": "Engineering",
+        "budget": "50000",
+        "client": "Internal"
+      },
+      "stats": {
+        "totalTasks": 2,
+        "completedTasks": 1,
+        "teamSize": 3
+      },
+      "teamMembers": ["alice", "bob", "charlie"],
+      "milestones": ["Design Complete", "MVP Ready", "Production Launch"],
+      "createdAt": "2024-01-01T00:00:00Z",
+      "status": "active"
+    }
+    """
+    
+    let result = try Project.schema.parse(instance: json)
+    
+    // Verify parsing succeeded
+    #expect(result.value != nil, "Expected successful parsing")
+    #expect(result.errors == nil, "Expected no validation errors")
+    
+    guard let project = result.value else {
+      throw TestError("Failed to parse project")
+    }
+    
+    // Verify basic properties
+    #expect(project.id == "proj-001")
+    #expect(project.name == "AI-Powered Task Manager")
+    #expect(project.status == .active)
+    
+    // Verify custom key schema dictionaries
+    #expect(project.tasksByPriority.count == 2)
+    #expect(project.tasksByPriority[.high]?.count == 1)
+    #expect(project.tasksByPriority[.medium]?.count == 1)
+    #expect(project.tasksByPriority[.low] == nil)
+    
+    #expect(project.tasksByEmotion.count == 2)
+    #expect(project.tasksByEmotion[.excited]?.count == 1)
+    #expect(project.tasksByEmotion[.calm]?.count == 1)
+    #expect(project.tasksByEmotion[.sad] == nil)
+    
+    // Verify string key dictionaries
+    #expect(project.metadata["department"] == "Engineering")
+    #expect(project.metadata["budget"] == "50000")
+    #expect(project.stats["totalTasks"] == 2)
+    #expect(project.stats["completedTasks"] == 1)
+    
+    // Verify arrays
+    #expect(project.teamMembers.count == 3)
+    #expect(project.teamMembers.contains("alice"))
+    #expect(project.milestones.count == 3)
+    #expect(project.milestones.contains("Design Complete"))
+    
+    // Verify nested task properties
+    let highPriorityTask = project.tasksByPriority[.high]?.first
+    #expect(highPriorityTask?.priority == .high)
+    #expect(highPriorityTask?.emotionalState == .excited)
+    #expect(highPriorityTask?.tags.contains("architecture") == true)
+  }
+  
+  @Test
+  func testParsingVsValidationWithInvalidKeys() throws {
+    let json = """
+    {
+      "id": "proj-002",
+      "name": "Invalid Project",
+      "description": "This project has invalid keys",
+      "tasksByPriority": {
+        "invalid_priority": [
+          {
+            "id": "task-003",
+            "title": "Invalid Task",
+            "description": "This task has invalid priority",
+            "priority": "invalid_priority",
+            "isCompleted": false,
+            "tags": ["invalid"],
+            "emotionalState": "invalid_emotion",
+            "createdAt": "2024-01-15T09:00:00Z"
+          }
+        ]
+      },
+      "tasksByEmotion": {
+        "invalid_emotion": []
+      },
+      "metadata": {},
+      "stats": {},
+      "teamMembers": ["alice"],
+      "milestones": [],
+      "createdAt": "2024-01-01T00:00:00Z",
+      "status": "planning"
+    }
+    """
+    
+    // Test parsing (lenient) - should succeed even with invalid keys
+    let parseResult = try Project.schema.parse(instance: json)
+    #expect(parseResult.value != nil, "Parsing should succeed (lenient)")
+    #expect(parseResult.errors == nil, "Parsing should not produce errors for invalid keys")
+    
+    // Verify that the data is parsed as expected
+    guard let project = parseResult.value else {
+      throw TestError("Failed to parse project")
+    }
+    
+    // The invalid keys are silently dropped during parsing (current behavior)
+    #expect(project.tasksByPriority.count == 0, "Invalid keys are dropped during parsing")
+    #expect(project.tasksByEmotion.count == 0, "Invalid keys are dropped during parsing")
+    
+    // Test validation (strict) - should fail with invalid keys
+    let schema = Project.schema.definition()
+    let validationResult = try schema.validate(instance: json)
+    #expect(validationResult.isValid == false, "Validation should fail with invalid keys")
+    #expect(validationResult.errors?.isEmpty == false, "Validation should produce errors")
+    
+    // Check that validation produced errors
+    if let errors = validationResult.errors {
+      #expect(errors.count == 1, "Should have validation errors for invalid keys")
+      #expect(errors[0].keyword == "properties", "Validation errors should be of type 'properties'")
+    }
+  }
+  
+  @Test
+  func testParsingVsValidationWithInvalidTypes() throws {
+    let json = """
+    {
+      "id": "proj-003",
+      "name": "Invalid Values Project",
+      "description": "This project has invalid types",
+      "tasksByPriority": {
+        "high": [
+          {
+            "id": "task-004",
+            "title": "Invalid Task",
+            "description": "This task has invalid types",
+            "priority": "high",
+            "isCompleted": "not_a_boolean",
+            "tags": "not_an_array",
+            "emotionalState": "high",
+            "createdAt": "2024-01-15T09:00:00Z"
+          }
+        ]
+      },
+      "tasksByEmotion": {
+        "happy": []
+      },
+      "metadata": {},
+      "stats": {
+        "totalTasks": "not_a_number"
+      },
+      "teamMembers": "not_an_array",
+      "milestones": [],
+      "createdAt": "2024-01-01T00:00:00Z",
+      "status": "invalid_status"
+    }
+    """
+    
+    // Test parsing (lenient) - should fail with fundamental type mismatches
+    let parseResult = try Project.schema.parse(instance: json)
+    #expect(parseResult.value == nil, "Parsing should fail with fundamental type mismatches")
+    #expect(parseResult.errors != nil, "Parsing should produce errors for type mismatches")
+    
+    // Verify we get type-related parse errors
+    if let errors = parseResult.errors {
+      #expect(errors.count > 0, "Expected parsing errors")
+      
+      // Check for type mismatch errors
+      let hasTypeMismatchErrors = errors.contains { error in
+        switch error {
+        case .typeMismatch: return true
+        default: return false
+        }
+      }
+      #expect(hasTypeMismatchErrors, "Should have type mismatch errors")
+    }
+    
+    // Test validation (strict) - should also fail
+    let schema = Project.schema.definition()
+    let validationResult = try schema.validate(instance: json)
+    #expect(validationResult.isValid == false, "Validation should fail with invalid types")
+    #expect(validationResult.errors?.isEmpty == false, "Validation should produce errors")
+  }
+  
+  @Test
+  func testEmptyProjectWithMinimalData() throws {
+    let json = """
+    {
+      "id": "proj-004",
+      "name": "Minimal Project",
+      "tasksByPriority": {},
+      "tasksByEmotion": {},
+      "metadata": {},
+      "stats": {},
+      "teamMembers": ["solo_dev"],
+      "milestones": [],
+      "createdAt": "2024-01-01T00:00:00Z",
+      "status": "planning"
+    }
+    """
+    
+    // Test parsing (lenient) - should succeed with minimal valid data
+    let parseResult = try Project.schema.parse(instance: json)
+    #expect(parseResult.value != nil, "Parsing should succeed with minimal data")
+    #expect(parseResult.errors == nil, "Parsing should not produce errors")
+    
+    guard let project = parseResult.value else {
+      throw TestError("Failed to parse project")
+    }
+    
+    // Verify basic properties
+    #expect(project.id == "proj-004")
+    #expect(project.name == "Minimal Project")
+    #expect(project.status == .planning)
+    #expect(project.description == nil, "Optional description should be nil when omitted")
+    
+    // Verify empty dictionaries are handled correctly
+    #expect(project.tasksByPriority.isEmpty)
+    #expect(project.tasksByEmotion.isEmpty)
+    #expect(project.metadata.isEmpty)
+    #expect(project.stats.isEmpty)
+    
+    // Verify arrays
+    #expect(project.teamMembers.count == 1)
+    #expect(project.teamMembers.contains("solo_dev"))
+    #expect(project.milestones.count == 0)
+    
+    // Test validation (strict) - should also pass for valid minimal data
+    let schema = Project.schema.definition()
+    let validationResult = try schema.validate(instance: json)
+    #expect(validationResult.isValid == true, "Validation should pass for minimal valid data")
+    #expect((validationResult.errors?.isEmpty ?? true) == true, "Should have no validation errors")
+  }
+}
+
+// MARK: - Test Utilities
+
+struct TestError: Error, CustomStringConvertible {
+  let message: String
+  
+  init(_ message: String) {
+    self.message = message
+  }
+  
+  var description: String {
+    message
+  }
+}
+

--- a/Tests/JSONSchemaIntegrationTests/DictionaryArrayIntegrationTests.swift
+++ b/Tests/JSONSchemaIntegrationTests/DictionaryArrayIntegrationTests.swift
@@ -2,7 +2,6 @@ import JSONSchema
 import JSONSchemaBuilder
 import Testing
 
-
 @Schemable
 enum Emotion {
   case happy
@@ -25,32 +24,32 @@ struct Task {
   /// Unique identifier for the task
   @SchemaOptions(.description("Unique identifier for the task"))
   let id: String
-  
+
   /// Title of the task
   @StringOptions(.minLength(1), .maxLength(100))
   let title: String
-  
+
   /// Detailed description of the task
   @StringOptions(.maxLength(500))
   let description: String?
-  
+
   /// Priority level of the task
   let priority: Priority
-  
+
   /// Whether the task is completed
   let isCompleted: Bool
-  
+
   /// Tags associated with the task
   @ArrayOptions(.minItems(0), .maxItems(10))
   let tags: [String]
-  
+
   /// Emotional state while working on the task
   let emotionalState: Emotion?
-  
+
   /// When the task was created
   @StringOptions(.format("date-time"))
   let createdAt: String
-  
+
   /// When the task is due
   @StringOptions(.format("date-time"))
   let dueDate: String?
@@ -60,39 +59,39 @@ struct Task {
 struct Project {
   /// Unique identifier for the project
   let id: String
-  
+
   /// Name of the project
   @StringOptions(.minLength(1), .maxLength(200))
   let name: String
-  
+
   /// Project description
   @StringOptions(.maxLength(1000))
   let description: String?
-  
+
   /// Tasks organized by priority
   let tasksByPriority: [Priority: [Task]]
-  
+
   /// Tasks organized by emotional state
   let tasksByEmotion: [Emotion: [Task]]
-  
+
   /// General project metadata
   let metadata: [String: String]
-  
+
   /// Project statistics
   let stats: [String: Int]
-  
+
   /// Project team members
   @ArrayOptions(.minItems(1))
   let teamMembers: [String]
-  
+
   /// Project milestones
   @ArrayOptions(.minItems(0))
   let milestones: [String]
-  
+
   /// When the project was created
   @StringOptions(.format("date-time"))
   let createdAt: String
-  
+
   /// Project status
   let status: ProjectStatus
 }
@@ -112,232 +111,232 @@ struct DictionaryArrayIntegrationTests {
   @Test
   func testValidProjectWithComplexDictionaries() throws {
     let json = """
-    {
-      "id": "proj-001",
-      "name": "AI-Powered Task Manager",
-      "description": "A sophisticated task management system with emotional intelligence",
-      "tasksByPriority": {
-        "high": [
-          {
-            "id": "task-001",
-            "title": "Design Core Architecture",
-            "description": "Create the foundational system design",
-            "priority": "high",
-            "isCompleted": false,
-            "tags": ["architecture", "design"],
-            "emotionalState": "excited",
-            "createdAt": "2024-01-15T09:00:00Z",
-            "dueDate": "2024-01-22T17:00:00Z"
-          }
-        ],
-        "medium": [
-          {
-            "id": "task-002",
-            "title": "Write Documentation",
-            "description": "Document the API endpoints",
-            "priority": "medium",
-            "isCompleted": true,
-            "tags": ["documentation", "api"],
-            "emotionalState": "calm",
-            "createdAt": "2024-01-10T14:00:00Z",
-            "dueDate": "2024-01-17T17:00:00Z"
-          }
-        ]
-      },
-      "tasksByEmotion": {
-        "excited": [
-          {
-            "id": "task-001",
-            "title": "Design Core Architecture",
-            "description": "Create the foundational system design",
-            "priority": "high",
-            "isCompleted": false,
-            "tags": ["architecture", "design"],
-            "emotionalState": "excited",
-            "createdAt": "2024-01-15T09:00:00Z",
-            "dueDate": "2024-01-22T17:00:00Z"
-          }
-        ],
-        "calm": [
-          {
-            "id": "task-002",
-            "title": "Write Documentation",
-            "description": "Document the API endpoints",
-            "priority": "medium",
-            "isCompleted": true,
-            "tags": ["documentation", "api"],
-            "emotionalState": "calm",
-            "createdAt": "2024-01-10T14:00:00Z",
-            "dueDate": "2024-01-17T17:00:00Z"
-          }
-        ]
-      },
-      "metadata": {
-        "department": "Engineering",
-        "budget": "50000",
-        "client": "Internal"
-      },
-      "stats": {
-        "totalTasks": 2,
-        "completedTasks": 1,
-        "teamSize": 3
-      },
-      "teamMembers": ["alice", "bob", "charlie"],
-      "milestones": ["Design Complete", "MVP Ready", "Production Launch"],
-      "createdAt": "2024-01-01T00:00:00Z",
-      "status": "active"
-    }
-    """
-    
+      {
+        "id": "proj-001",
+        "name": "AI-Powered Task Manager",
+        "description": "A sophisticated task management system with emotional intelligence",
+        "tasksByPriority": {
+          "high": [
+            {
+              "id": "task-001",
+              "title": "Design Core Architecture",
+              "description": "Create the foundational system design",
+              "priority": "high",
+              "isCompleted": false,
+              "tags": ["architecture", "design"],
+              "emotionalState": "excited",
+              "createdAt": "2024-01-15T09:00:00Z",
+              "dueDate": "2024-01-22T17:00:00Z"
+            }
+          ],
+          "medium": [
+            {
+              "id": "task-002",
+              "title": "Write Documentation",
+              "description": "Document the API endpoints",
+              "priority": "medium",
+              "isCompleted": true,
+              "tags": ["documentation", "api"],
+              "emotionalState": "calm",
+              "createdAt": "2024-01-10T14:00:00Z",
+              "dueDate": "2024-01-17T17:00:00Z"
+            }
+          ]
+        },
+        "tasksByEmotion": {
+          "excited": [
+            {
+              "id": "task-001",
+              "title": "Design Core Architecture",
+              "description": "Create the foundational system design",
+              "priority": "high",
+              "isCompleted": false,
+              "tags": ["architecture", "design"],
+              "emotionalState": "excited",
+              "createdAt": "2024-01-15T09:00:00Z",
+              "dueDate": "2024-01-22T17:00:00Z"
+            }
+          ],
+          "calm": [
+            {
+              "id": "task-002",
+              "title": "Write Documentation",
+              "description": "Document the API endpoints",
+              "priority": "medium",
+              "isCompleted": true,
+              "tags": ["documentation", "api"],
+              "emotionalState": "calm",
+              "createdAt": "2024-01-10T14:00:00Z",
+              "dueDate": "2024-01-17T17:00:00Z"
+            }
+          ]
+        },
+        "metadata": {
+          "department": "Engineering",
+          "budget": "50000",
+          "client": "Internal"
+        },
+        "stats": {
+          "totalTasks": 2,
+          "completedTasks": 1,
+          "teamSize": 3
+        },
+        "teamMembers": ["alice", "bob", "charlie"],
+        "milestones": ["Design Complete", "MVP Ready", "Production Launch"],
+        "createdAt": "2024-01-01T00:00:00Z",
+        "status": "active"
+      }
+      """
+
     let result = try Project.schema.parse(instance: json)
-    
+
     // Verify parsing succeeded
     #expect(result.value != nil, "Expected successful parsing")
     #expect(result.errors == nil, "Expected no validation errors")
-    
+
     guard let project = result.value else {
       throw TestError("Failed to parse project")
     }
-    
+
     // Verify basic properties
     #expect(project.id == "proj-001")
     #expect(project.name == "AI-Powered Task Manager")
     #expect(project.status == .active)
-    
+
     // Verify custom key schema dictionaries
     #expect(project.tasksByPriority.count == 2)
     #expect(project.tasksByPriority[.high]?.count == 1)
     #expect(project.tasksByPriority[.medium]?.count == 1)
     #expect(project.tasksByPriority[.low] == nil)
-    
+
     #expect(project.tasksByEmotion.count == 2)
     #expect(project.tasksByEmotion[.excited]?.count == 1)
     #expect(project.tasksByEmotion[.calm]?.count == 1)
     #expect(project.tasksByEmotion[.sad] == nil)
-    
+
     // Verify string key dictionaries
     #expect(project.metadata["department"] == "Engineering")
     #expect(project.metadata["budget"] == "50000")
     #expect(project.stats["totalTasks"] == 2)
     #expect(project.stats["completedTasks"] == 1)
-    
+
     // Verify arrays
     #expect(project.teamMembers.count == 3)
     #expect(project.teamMembers.contains("alice"))
     #expect(project.milestones.count == 3)
     #expect(project.milestones.contains("Design Complete"))
-    
+
     // Verify nested task properties
     let highPriorityTask = project.tasksByPriority[.high]?.first
     #expect(highPriorityTask?.priority == .high)
     #expect(highPriorityTask?.emotionalState == .excited)
     #expect(highPriorityTask?.tags.contains("architecture") == true)
   }
-  
+
   @Test
   func testParsingVsValidationWithInvalidKeys() throws {
     let json = """
-    {
-      "id": "proj-002",
-      "name": "Invalid Project",
-      "description": "This project has invalid keys",
-      "tasksByPriority": {
-        "invalid_priority": [
-          {
-            "id": "task-003",
-            "title": "Invalid Task",
-            "description": "This task has invalid priority",
-            "priority": "invalid_priority",
-            "isCompleted": false,
-            "tags": ["invalid"],
-            "emotionalState": "invalid_emotion",
-            "createdAt": "2024-01-15T09:00:00Z"
-          }
-        ]
-      },
-      "tasksByEmotion": {
-        "invalid_emotion": []
-      },
-      "metadata": {},
-      "stats": {},
-      "teamMembers": ["alice"],
-      "milestones": [],
-      "createdAt": "2024-01-01T00:00:00Z",
-      "status": "planning"
-    }
-    """
-    
+      {
+        "id": "proj-002",
+        "name": "Invalid Project",
+        "description": "This project has invalid keys",
+        "tasksByPriority": {
+          "invalid_priority": [
+            {
+              "id": "task-003",
+              "title": "Invalid Task",
+              "description": "This task has invalid priority",
+              "priority": "invalid_priority",
+              "isCompleted": false,
+              "tags": ["invalid"],
+              "emotionalState": "invalid_emotion",
+              "createdAt": "2024-01-15T09:00:00Z"
+            }
+          ]
+        },
+        "tasksByEmotion": {
+          "invalid_emotion": []
+        },
+        "metadata": {},
+        "stats": {},
+        "teamMembers": ["alice"],
+        "milestones": [],
+        "createdAt": "2024-01-01T00:00:00Z",
+        "status": "planning"
+      }
+      """
+
     // Test parsing (lenient) - should succeed even with invalid keys
     let parseResult = try Project.schema.parse(instance: json)
     #expect(parseResult.value != nil, "Parsing should succeed (lenient)")
     #expect(parseResult.errors == nil, "Parsing should not produce errors for invalid keys")
-    
+
     // Verify that the data is parsed as expected
     guard let project = parseResult.value else {
       throw TestError("Failed to parse project")
     }
-    
+
     // The invalid keys are silently dropped during parsing (current behavior)
     #expect(project.tasksByPriority.count == 0, "Invalid keys are dropped during parsing")
     #expect(project.tasksByEmotion.count == 0, "Invalid keys are dropped during parsing")
-    
+
     // Test validation (strict) - should fail with invalid keys
     let schema = Project.schema.definition()
     let validationResult = try schema.validate(instance: json)
     #expect(validationResult.isValid == false, "Validation should fail with invalid keys")
     #expect(validationResult.errors?.isEmpty == false, "Validation should produce errors")
-    
+
     // Check that validation produced errors
     if let errors = validationResult.errors {
       #expect(errors.count == 1, "Should have validation errors for invalid keys")
       #expect(errors[0].keyword == "properties", "Validation errors should be of type 'properties'")
     }
   }
-  
+
   @Test
   func testParsingVsValidationWithInvalidTypes() throws {
     let json = """
-    {
-      "id": "proj-003",
-      "name": "Invalid Values Project",
-      "description": "This project has invalid types",
-      "tasksByPriority": {
-        "high": [
-          {
-            "id": "task-004",
-            "title": "Invalid Task",
-            "description": "This task has invalid types",
-            "priority": "high",
-            "isCompleted": "not_a_boolean",
-            "tags": "not_an_array",
-            "emotionalState": "high",
-            "createdAt": "2024-01-15T09:00:00Z"
-          }
-        ]
-      },
-      "tasksByEmotion": {
-        "happy": []
-      },
-      "metadata": {},
-      "stats": {
-        "totalTasks": "not_a_number"
-      },
-      "teamMembers": "not_an_array",
-      "milestones": [],
-      "createdAt": "2024-01-01T00:00:00Z",
-      "status": "invalid_status"
-    }
-    """
-    
+      {
+        "id": "proj-003",
+        "name": "Invalid Values Project",
+        "description": "This project has invalid types",
+        "tasksByPriority": {
+          "high": [
+            {
+              "id": "task-004",
+              "title": "Invalid Task",
+              "description": "This task has invalid types",
+              "priority": "high",
+              "isCompleted": "not_a_boolean",
+              "tags": "not_an_array",
+              "emotionalState": "high",
+              "createdAt": "2024-01-15T09:00:00Z"
+            }
+          ]
+        },
+        "tasksByEmotion": {
+          "happy": []
+        },
+        "metadata": {},
+        "stats": {
+          "totalTasks": "not_a_number"
+        },
+        "teamMembers": "not_an_array",
+        "milestones": [],
+        "createdAt": "2024-01-01T00:00:00Z",
+        "status": "invalid_status"
+      }
+      """
+
     // Test parsing (lenient) - should fail with fundamental type mismatches
     let parseResult = try Project.schema.parse(instance: json)
     #expect(parseResult.value == nil, "Parsing should fail with fundamental type mismatches")
     #expect(parseResult.errors != nil, "Parsing should produce errors for type mismatches")
-    
+
     // Verify we get type-related parse errors
     if let errors = parseResult.errors {
       #expect(errors.count > 0, "Expected parsing errors")
-      
+
       // Check for type mismatch errors
       let hasTypeMismatchErrors = errors.contains { error in
         switch error {
@@ -347,57 +346,57 @@ struct DictionaryArrayIntegrationTests {
       }
       #expect(hasTypeMismatchErrors, "Should have type mismatch errors")
     }
-    
+
     // Test validation (strict) - should also fail
     let schema = Project.schema.definition()
     let validationResult = try schema.validate(instance: json)
     #expect(validationResult.isValid == false, "Validation should fail with invalid types")
     #expect(validationResult.errors?.isEmpty == false, "Validation should produce errors")
   }
-  
+
   @Test
   func testEmptyProjectWithMinimalData() throws {
     let json = """
-    {
-      "id": "proj-004",
-      "name": "Minimal Project",
-      "tasksByPriority": {},
-      "tasksByEmotion": {},
-      "metadata": {},
-      "stats": {},
-      "teamMembers": ["solo_dev"],
-      "milestones": [],
-      "createdAt": "2024-01-01T00:00:00Z",
-      "status": "planning"
-    }
-    """
-    
+      {
+        "id": "proj-004",
+        "name": "Minimal Project",
+        "tasksByPriority": {},
+        "tasksByEmotion": {},
+        "metadata": {},
+        "stats": {},
+        "teamMembers": ["solo_dev"],
+        "milestones": [],
+        "createdAt": "2024-01-01T00:00:00Z",
+        "status": "planning"
+      }
+      """
+
     // Test parsing (lenient) - should succeed with minimal valid data
     let parseResult = try Project.schema.parse(instance: json)
     #expect(parseResult.value != nil, "Parsing should succeed with minimal data")
     #expect(parseResult.errors == nil, "Parsing should not produce errors")
-    
+
     guard let project = parseResult.value else {
       throw TestError("Failed to parse project")
     }
-    
+
     // Verify basic properties
     #expect(project.id == "proj-004")
     #expect(project.name == "Minimal Project")
     #expect(project.status == .planning)
     #expect(project.description == nil, "Optional description should be nil when omitted")
-    
+
     // Verify empty dictionaries are handled correctly
     #expect(project.tasksByPriority.isEmpty)
     #expect(project.tasksByEmotion.isEmpty)
     #expect(project.metadata.isEmpty)
     #expect(project.stats.isEmpty)
-    
+
     // Verify arrays
     #expect(project.teamMembers.count == 1)
     #expect(project.teamMembers.contains("solo_dev"))
     #expect(project.milestones.count == 0)
-    
+
     // Test validation (strict) - should also pass for valid minimal data
     let schema = Project.schema.definition()
     let validationResult = try schema.validate(instance: json)
@@ -410,13 +409,12 @@ struct DictionaryArrayIntegrationTests {
 
 struct TestError: Error, CustomStringConvertible {
   let message: String
-  
+
   init(_ message: String) {
     self.message = message
   }
-  
+
   var description: String {
     message
   }
 }
-

--- a/Tests/JSONSchemaMacroTests/SchemableEnumExpansionTests.swift
+++ b/Tests/JSONSchemaMacroTests/SchemableEnumExpansionTests.swift
@@ -318,6 +318,7 @@ import Testing
                           JSONString()
                         }
                         .map(\\.1)
+                        .map(\\.matches)
                     }
                       .required()
                   }

--- a/Tests/JSONSchemaMacroTests/SchemableExpansionTests.swift
+++ b/Tests/JSONSchemaMacroTests/SchemableExpansionTests.swift
@@ -98,6 +98,7 @@ struct SchemableExpansionTests {
                     JSONNumber()
                   }
                   .map(\\.1)
+                  .map(\\.matches)
                 }
                 .required()
                 JSONProperty(key: "conditionsByLocation") {
@@ -152,6 +153,7 @@ struct SchemableExpansionTests {
                     JSONNumber()
                   }
                   .map(\\.1)
+                  .map(\\.matches)
                 }
                 .required()
               }
@@ -816,12 +818,15 @@ struct SchemableExpansionTests {
                     JSONInteger()
                   }
                   .map { value in
-                    Dictionary(
-                      uniqueKeysWithValues: zip(value.0.1.seen, value.0.1.raw).compactMap { seen, raw in
-                        value.1.matches[raw].map {
-                          (seen, $0)
+                    let (_, capturedNames) = value.0
+                    let additionalProperties = value.1
+                    return Dictionary(
+                      uniqueKeysWithValues: zip(capturedNames.seen, capturedNames.raw)
+                        .compactMap { parsedKey, rawKey in
+                          additionalProperties.matches[rawKey].map { parsedValue in
+                            (parsedKey, parsedValue)
+                          }
                         }
-                      }
                     )
                   }
                 }

--- a/Tests/JSONSchemaMacroTests/SchemableExpansionTests.swift
+++ b/Tests/JSONSchemaMacroTests/SchemableExpansionTests.swift
@@ -166,6 +166,7 @@ struct SchemableExpansionTests {
     )
   }
 
+
   @Test(arguments: ["struct", "class"]) func multipleBindings(declarationType: String) {
     assertMacroExpansion(
       """

--- a/Tests/JSONSchemaMacroTests/TypeSpecificSchemaOptionsTests.swift
+++ b/Tests/JSONSchemaMacroTests/TypeSpecificSchemaOptionsTests.swift
@@ -282,6 +282,10 @@ struct ObjectOptionsTests {
                   JSONString()
                     .pattern("^[A-Za-z_][A-Za-z0-9_]*$")
               }
+              // Drop the parse information. Use custom builder if needed.
+              .map {
+                $0.0
+              }
               .unevaluatedProperties {
                   JSONString()
               }


### PR DESCRIPTION
## Summary
- capture property names seen during parsing with new `CapturedPropertyNames`
- propagate `propertyNames{}` through a new component and update macro expansion
- allow `@Schemable` dictionaries keyed by enums via generated `propertyNames` mapping
- document and test property name capture

## Testing
- `swift test`

Closes #111 

------
https://chatgpt.com/codex/tasks/task_e_689ad7ec6bbc8331ba91ca3a5490f1e8