### PR TITLE
Support nested types with @Schemable macro

### DIFF
--- a/Tests/JSONSchemaMacroTests/SchemableExpansionTests.swift
+++ b/Tests/JSONSchemaMacroTests/SchemableExpansionTests.swift
@@ -1046,11 +1046,10 @@ struct SchemableExpansionTests {
                     switch $0 {
                     case "sunny":
                       return Self.sunny
-
                     case "cloudy":
                       return Self.cloudy
-
-                    default: return nil
+                    default:
+                      return nil
                     }
                   }
               }
@@ -1107,10 +1106,10 @@ struct SchemableExpansionTests {
           }
         }
 
-        extension Weather: Schemable {
+        extension Weather.Forecast: Schemable {
         }
 
-        extension Weather.Forecast: Schemable {
+        extension Weather: Schemable {
         }
         """,
       macros: testMacros


### PR DESCRIPTION
## Description

Adds support for applying the `@Schemable` macro to nested types at arbitrary depth. Previously, the macro could only be applied to top-level types. This enhancement allows developers to use `@Schemable` on types nested directly within other types or within extensions, which is a common pattern for organizing related types.

The macro now correctly generates fully qualified type names (e.g., `Weather.Forecast.Hourly`) when creating the `Schemable` protocol conformance extension.

**Example - Types nested in extensions:**

```swift
  public extension Weather {
      @Schemable
      struct Forecast: Codable {
          let temperature: Double
          let humidity: Int
      }
  }

  // Generated extension uses fully qualified name:
  // extension Weather.Forecast: Schemable {}

  // Schema is accessible:
  let schema = Weather.Forecast.schema
```

**Example - Directly nested types:**

```swift

  @Schemable
  struct Weather: Codable {
      let location: String

      @Schemable
      struct Forecast: Codable {
          let temperature: Double
          let humidity: Int
      }
  }

  // Generates both extensions:
  // extension Weather: Schemable {}
  // extension Weather.Forecast: Schemable {}

```

**Works at arbitrary nesting depth:**

```swift
  public extension Weather {
    struct Forecast {
      struct Hourly {
        @Schemable
        struct Detailed: Codable {
          let temperature: Double
        }
      }
    }
  }

  // Generates: extension Weather.Forecast.Hourly.Detailed: Schemable {}
```

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

- The implementation walks the syntax tree to collect all parent type names (structs, classes, enums, actors)
- Comprehensive test coverage added for 1, 2, and 3-level nesting with both struct and class declarations
- No breaking changes - existing usage of @Schemable on top-level types continues to work exactly as before
