### PR TITLE
Exclude static properties from schema generation

### DIFF
--- a/Sources/JSONSchemaMacro/Schemable/SwiftSyntaxExtensions.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SwiftSyntaxExtensions.swift
@@ -237,11 +237,18 @@ extension VariableDeclSyntax {
     }
     .contains(where: { $0 == "ExcludeFromSchema" })
   }
+
+  var isStatic: Bool {
+    modifiers.contains { modifier in
+      modifier.name.tokenKind == .keyword(.static)
+    }
+  }
 }
 
 extension MemberBlockItemListSyntax {
   func schemableMembers() -> [SchemableMember] {
     self.compactMap { $0.decl.as(VariableDeclSyntax.self) }
+      .filter { !$0.isStatic }
       .flatMap { variableDecl in variableDecl.bindings.map { (variableDecl, $0) } }
       .filter { $0.0.shouldExcludeFromSchema }.filter { $0.1.isStoredProperty }
       .compactMap(SchemableMember.init)


### PR DESCRIPTION
## Description

Fixes a bug where static properties were incorrectly included in generated JSON schemas. Static properties should be excluded since they are not part of instance data and cannot be initialized from JSON.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

Added test coverage for static let, static var, and computed static properties to ensure they are properly excluded from schema generation.
