### PR TITLE
Validation result improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,20 +239,6 @@ let result2 = schema.validate(instance2)
 dump(result2, name: "Instance 2 Validation Result")
 ```
 
-### Validation Output Levels
-
-`ValidationResult` can render the JSON Schema specification's four output formats so you can choose the right level of detail for downstream tooling.
-
-```swift
-let result = schema.validate(instance2)
-let verboseJSON = try result.renderedOutput(level: .verbose)
-
-// or use a configuration wrapper
-let detailedJSON = try result.renderedOutput(configuration: .detailed)
-```
-
-The levels follow the [JSON Schema output specification](https://json-schema.org/draft/2020-12/output/schema).
-
 <details>
   <summary>Instance 1 Validation Result</summary>
 
@@ -322,6 +308,20 @@ The levels follow the [JSON Schema output specification](https://json-schema.org
   ```
 </details>
 <br/>
+
+### Validation Output Levels
+
+`ValidationResult` can render the JSON Schema specification's four output formats so you can choose the right level of detail for downstream tooling.
+
+```swift
+let result = schema.validate(instance2)
+let verboseJSON = try result.renderedOutput(level: .verbose)
+
+// or use a configuration wrapper
+let detailedJSON = try result.renderedOutput(configuration: .detailed)
+```
+
+The levels follow the [JSON Schema output specification](https://json-schema.org/draft/2020-12/output/schema).
 
 ## Parsing
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,20 @@ let result2 = schema.validate(instance2)
 dump(result2, name: "Instance 2 Validation Result")
 ```
 
+### Validation Output Levels
+
+`ValidationResult` can render the JSON Schema specification's four output formats so you can choose the right level of detail for downstream tooling.
+
+```swift
+let result = schema.validate(instance2)
+let verboseJSON = try result.renderedOutput(level: .verbose)
+
+// or use a configuration wrapper
+let detailedJSON = try result.renderedOutput(configuration: .detailed)
+```
+
+The levels follow the [JSON Schema output specification](https://json-schema.org/draft/2020-12/output/schema).
+
 <details>
   <summary>Instance 1 Validation Result</summary>
 

--- a/README.md
+++ b/README.md
@@ -309,20 +309,6 @@ dump(result2, name: "Instance 2 Validation Result")
 </details>
 <br/>
 
-### Validation Output Levels
-
-`ValidationResult` can render the JSON Schema specification's four output formats so you can choose the right level of detail for downstream tooling.
-
-```swift
-let result = schema.validate(instance2)
-let verboseJSON = try result.renderedOutput(level: .verbose)
-
-// or use a configuration wrapper
-let detailedJSON = try result.renderedOutput(configuration: .detailed)
-```
-
-The levels follow the [JSON Schema output specification](https://json-schema.org/draft/2020-12/output/schema).
-
 ## Parsing
 
 When using [builders](#schema-generation) or [macros](#macros), you can also parse JSON instances into Swift types.

--- a/Sources/JSONSchema/Annotations/Annotation.swift
+++ b/Sources/JSONSchema/Annotations/Annotation.swift
@@ -2,14 +2,14 @@ struct Annotation<Keyword: AnnotationProducingKeyword>: Sendable {
   let keyword: KeywordIdentifier
   let instanceLocation: JSONPointer
   let schemaLocation: JSONPointer
-  let absoluteSchemaLocation: JSONPointer?
+  let absoluteSchemaLocation: String?
   let value: Keyword.AnnotationValue
 
   init(
     keyword: KeywordIdentifier,
     instanceLocation: JSONPointer,
     schemaLocation: JSONPointer,
-    absoluteSchemaLocation: JSONPointer? = nil,
+    absoluteSchemaLocation: String? = nil,
     value: Keyword.AnnotationValue
   ) {
     self.keyword = keyword
@@ -23,7 +23,7 @@ struct Annotation<Keyword: AnnotationProducingKeyword>: Sendable {
     self.keyword = type(of: keyword).name
     self.instanceLocation = instanceLocation
     self.schemaLocation = keyword.context.location
-    self.absoluteSchemaLocation = nil
+    self.absoluteSchemaLocation = keyword.context.absoluteKeywordLocation()
     self.value = value
   }
 }
@@ -32,7 +32,7 @@ public protocol AnyAnnotation: Sendable {
   var keyword: KeywordIdentifier { get }
   var instanceLocation: JSONPointer { get }
   var schemaLocation: JSONPointer { get }
-  var absoluteSchemaLocation: JSONPointer? { get }
+  var absoluteSchemaLocation: String? { get }
   var jsonValue: JSONValue { get }
 
   func merged(with other: AnyAnnotation) -> AnyAnnotation?
@@ -56,6 +56,7 @@ extension Annotation {
       keyword: self.keyword,
       instanceLocation: self.instanceLocation,
       schemaLocation: self.schemaLocation,
+      absoluteSchemaLocation: self.absoluteSchemaLocation,
       value: mergedValue
     )
   }

--- a/Sources/JSONSchema/Annotations/Annotation.swift
+++ b/Sources/JSONSchema/Annotations/Annotation.swift
@@ -47,6 +47,15 @@ extension Annotation: AnyAnnotation where Keyword.AnnotationValue: AnnotationVal
 }
 
 extension Annotation {
+  /// Merges two annotations that share an instance location and keyword type.
+  ///
+  /// - Important: When the two annotations originate from different schema
+  ///   locations (for example, sibling branches of an `allOf` that both
+  ///   produce `properties` annotations), the merged annotation keeps
+  ///   `self`'s `schemaLocation` and `absoluteSchemaLocation`. The JSON
+  ///   Schema spec encourages preserving every source for downstream
+  ///   consumers; a future change should switch the annotation container
+  ///   to a multi-value keyed structure so each source survives the merge.
   func merged(with other: AnyAnnotation) -> AnyAnnotation? {
     guard let otherAnnotation = other as? Annotation<Keyword> else {
       return nil

--- a/Sources/JSONSchema/Annotations/Annotation.swift
+++ b/Sources/JSONSchema/Annotations/Annotation.swift
@@ -1,15 +1,17 @@
+import Foundation
+
 struct Annotation<Keyword: AnnotationProducingKeyword>: Sendable {
   let keyword: KeywordIdentifier
   let instanceLocation: JSONPointer
   let schemaLocation: JSONPointer
-  let absoluteSchemaLocation: String?
+  let absoluteSchemaLocation: URL?
   let value: Keyword.AnnotationValue
 
   init(
     keyword: KeywordIdentifier,
     instanceLocation: JSONPointer,
     schemaLocation: JSONPointer,
-    absoluteSchemaLocation: String? = nil,
+    absoluteSchemaLocation: URL? = nil,
     value: Keyword.AnnotationValue
   ) {
     self.keyword = keyword
@@ -32,7 +34,7 @@ public protocol AnyAnnotation: Sendable {
   var keyword: KeywordIdentifier { get }
   var instanceLocation: JSONPointer { get }
   var schemaLocation: JSONPointer { get }
-  var absoluteSchemaLocation: String? { get }
+  var absoluteSchemaLocation: URL? { get }
   var jsonValue: JSONValue { get }
 
   func merged(with other: AnyAnnotation) -> AnyAnnotation?

--- a/Sources/JSONSchema/Documentation.docc/Documentation.md
+++ b/Sources/JSONSchema/Documentation.docc/Documentation.md
@@ -1,13 +1,53 @@
 # ``JSONSchema``
 
-<!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
+The ``JSONSchema`` target provides the core runtime for working with JSON Schema documents in Swift. It focuses on representing schemas, decoding/encoding them, validating data, and navigating JSON documents with strongly typed utilities.
 
 ## Overview
 
-<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+- **Schema representation** – ``Schema`` loads schemas from Swift builders, JSON strings, or decoded `JSONValue` instances.
+- **JSON data model** – ``JSONValue`` models any JSON payload, enabling type-safe validation and letting you construct instances directly in Swift without juggling `Any`.
+- **Pointer navigation** – ``JSONPointer`` provide convenient traversal of deeply nested JSON structures and map cleanly onto the JSON Schema specification's pointer syntax.
+- **Validation pipeline** – Calling ``Schema/validate(_:)`` returns a ``ValidationResult`` containing errors, annotations, and metadata about which keywords were evaluated. You can emit spec-compliant diagnostics through ``ValidationOutputLevel`` and ``ValidationOutputConfiguration``.
+- **Format validators** – The ``FormatValidator`` registry ships with built-in validators (URI, email, hostname, UUID, duration, and more) and lets you register custom implementations to extend your dialect.
+- **Dialect support** – ``Dialect`` encapsulates draft-specific features (like metaschemas, vocabulary requirements, and `$dynamicRef` semantics). You can opt into draft 2020-12 or supply your own dialect definition.
+- **Codable integration** – ``JSONValue``, ``Schema``, annotations, and validation results all conform to Swift's `Codable` protocols, making it straightforward to serialize or inspect them in tooling.
+
+## Validation Lifecycle
+
+```swift
+let schema = try Schema(instance: schemaJSONData)
+let payload: JSONValue = ["name": "Ada", "age": 37]
+
+let result = schema.validate(payload)
+
+if result.isValid {
+	print("Document is valid")
+} else {
+	for error in result.errors ?? [] {
+		print("Keyword", error.keyword, "failed at", error.instanceLocation)
+	}
+}
+
+let verboseOutput = try result.renderedOutput(level: .verbose)
+```
+
+Validation is spec-compliant: references resolve through ``JSONPointer`` paths, annotations flow through in-place applicators, and custom formats/dialects participate automatically. The repository keeps a synchronized copy of the official JSON Schema Test Suite (including the output tests), and `swift test` runs every draft 2020-12 fixture to maintain compatibility.
 
 ## Topics
 
-### <!--@START_MENU_TOKEN@-->Group<!--@END_MENU_TOKEN@-->
+### Core Types
 
-- <!--@START_MENU_TOKEN@-->``Symbol``<!--@END_MENU_TOKEN@-->
+- ``Schema``
+- ``JSONValue``
+- ``JSONPointer``
+- ``ValidationResult``
+
+### Validation Output
+
+- ``ValidationOutputLevel``
+- ``ValidationOutputConfiguration``
+
+### Infrastructure
+
+- ``FormatValidator``
+- ``Dialect``

--- a/Sources/JSONSchema/Keywords/Keyword.swift
+++ b/Sources/JSONSchema/Keywords/Keyword.swift
@@ -30,3 +30,10 @@ package struct KeywordContext {
     self.uri = uri
   }
 }
+
+extension KeywordContext {
+  func absoluteKeywordLocation(for pointer: JSONPointer? = nil) -> String? {
+    let pointer = pointer ?? location
+    return pointer.absoluteLocation(relativeTo: uri)
+  }
+}

--- a/Sources/JSONSchema/Keywords/Keyword.swift
+++ b/Sources/JSONSchema/Keywords/Keyword.swift
@@ -32,7 +32,7 @@ package struct KeywordContext {
 }
 
 extension KeywordContext {
-  func absoluteKeywordLocation(for pointer: JSONPointer? = nil) -> String? {
+  func absoluteKeywordLocation(for pointer: JSONPointer? = nil) -> URL? {
     let pointer = pointer ?? location
     return pointer.absoluteLocation(relativeTo: uri)
   }

--- a/Sources/JSONSchema/Keywords/Keywords+Applicator.swift
+++ b/Sources/JSONSchema/Keywords/Keywords+Applicator.swift
@@ -931,7 +931,12 @@ extension JSONValue {
       context: context.context,
       baseURI: context.uri
     ))
-      ?? BooleanSchema(schemaValue: true, location: context.location, context: context.context)
+      ?? BooleanSchema(
+        schemaValue: true,
+        location: context.location,
+        context: context.context,
+        documentURL: context.uri
+      )
       .asSchema()
   }
 }
@@ -959,6 +964,7 @@ struct ValidationResultBuilder {
             keyword: type(of: keyword).name,
             message: "Validation failed",
             keywordLocation: keyword.context.location,
+            absoluteKeywordLocation: keyword.context.absoluteKeywordLocation(),
             instanceLocation: instanceLocation
           )
         )

--- a/Sources/JSONSchema/Keywords/Keywords+Applicator.swift
+++ b/Sources/JSONSchema/Keywords/Keywords+Applicator.swift
@@ -947,7 +947,12 @@ extension JSONValue {
       context: context.context,
       baseURI: context.uri
     ))
-      ?? BooleanSchema(schemaValue: true, location: context.location, context: context.context)
+      ?? BooleanSchema(
+        schemaValue: true,
+        location: context.location,
+        context: context.context,
+        documentURL: context.uri
+      )
       .asSchema()
   }
 }
@@ -975,6 +980,7 @@ struct ValidationResultBuilder {
             keyword: type(of: keyword).name,
             message: "Validation failed",
             keywordLocation: keyword.context.location,
+            absoluteKeywordLocation: keyword.context.absoluteKeywordLocation(),
             instanceLocation: instanceLocation
           )
         )

--- a/Sources/JSONSchema/Keywords/Keywords+Metadata.swift
+++ b/Sources/JSONSchema/Keywords/Keywords+Metadata.swift
@@ -1,9 +1,16 @@
 /// https://json-schema.org/draft/2020-12/meta/meta-data
-protocol MetadataKeyword: Keyword {}
+protocol MetadataKeyword: Keyword, AnnotationProducingKeyword where AnnotationValue == JSONValue {}
 
 extension MetadataKeyword {
   package static var vocabulary: String {
     "https://json-schema.org/draft/2020-12/vocab/meta-data"
+  }
+
+  package func recordAnnotation(
+    at instanceLocation: JSONPointer,
+    using annotations: inout AnnotationContainer
+  ) {
+    annotations.insert(keyword: self, at: instanceLocation, value: value)
   }
 }
 

--- a/Sources/JSONSchema/Keywords/Keywords+Reference.swift
+++ b/Sources/JSONSchema/Keywords/Keywords+Reference.swift
@@ -52,9 +52,14 @@ extension Keywords {
       var refAnnotations = AnnotationContainer()
       let result = schema.validate(input, at: instanceLocation, annotations: &refAnnotations)
       if !result.isValid {
+        let prefixedErrors =
+          result.errors?
+          .map {
+            $0.prefixedKeywordLocation(with: self.context.location, removingBase: schema.location)
+          } ?? []
         throw ValidationIssue.referenceValidationFailure(
           ref: referenceURI,
-          errors: result.errors ?? []
+          errors: prefixedErrors
         )
       }
       annotations.merge(refAnnotations)
@@ -102,9 +107,14 @@ extension Keywords {
       var refAnnotations = AnnotationContainer()
       let result = schema.validate(input, at: instanceLocation, annotations: &refAnnotations)
       if !result.isValid {
+        let prefixedErrors =
+          result.errors?
+          .map {
+            $0.prefixedKeywordLocation(with: self.context.location, removingBase: schema.location)
+          } ?? []
         throw ValidationIssue.referenceValidationFailure(
           ref: referenceURI,
-          errors: result.errors ?? []
+          errors: prefixedErrors
         )
       }
       annotations.merge(refAnnotations)
@@ -300,7 +310,7 @@ struct ReferenceResolver {
     }
     return try Schema(
       rawSchema: subRawSchema,
-      location: location,
+      location: pointer,
       context: context,
       baseURI: referenceURL
     )

--- a/Sources/JSONSchema/Keywords/Keywords+Reference.swift
+++ b/Sources/JSONSchema/Keywords/Keywords+Reference.swift
@@ -52,9 +52,14 @@ extension Keywords {
       var refAnnotations = AnnotationContainer()
       let result = schema.validate(input, at: instanceLocation, annotations: &refAnnotations)
       if !result.isValid {
+        let prefixedErrors =
+          result.errors?
+          .map {
+            $0.prefixedKeywordLocation(with: self.context.location, removingBase: schema.location)
+          } ?? []
         throw ValidationIssue.referenceValidationFailure(
           ref: referenceURI,
-          errors: result.errors ?? []
+          errors: prefixedErrors
         )
       }
       annotations.merge(refAnnotations)
@@ -102,9 +107,14 @@ extension Keywords {
       var refAnnotations = AnnotationContainer()
       let result = schema.validate(input, at: instanceLocation, annotations: &refAnnotations)
       if !result.isValid {
+        let prefixedErrors =
+          result.errors?
+          .map {
+            $0.prefixedKeywordLocation(with: self.context.location, removingBase: schema.location)
+          } ?? []
         throw ValidationIssue.referenceValidationFailure(
           ref: referenceURI,
-          errors: result.errors ?? []
+          errors: prefixedErrors
         )
       }
       annotations.merge(refAnnotations)
@@ -314,7 +324,7 @@ struct ReferenceResolver {
     }
     return try Schema(
       rawSchema: subRawSchema,
-      location: location,
+      location: pointer,
       context: context,
       baseURI: referenceURL
     )

--- a/Sources/JSONSchema/Pointers/JSONPointer.swift
+++ b/Sources/JSONSchema/Pointers/JSONPointer.swift
@@ -38,6 +38,12 @@ public struct JSONPointer: Sendable, Hashable {
     return pointer
   }
 
+  /// Returns a new pointer created by appending the path components of another pointer.
+  func appending(pointer other: JSONPointer) -> JSONPointer {
+    guard !other.path.isEmpty else { return self }
+    return JSONPointer(path: self.path + other.path)
+  }
+
   func dropLast() -> JSONPointer {
     guard path.count > 0 else { return self }
 

--- a/Sources/JSONSchema/Pointers/JSONPointer.swift
+++ b/Sources/JSONSchema/Pointers/JSONPointer.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 ///  JSON Pointer defines a string syntax for identifying a specific value within a JavaScript Object Notation (JSON) document.
 /// https://datatracker.ietf.org/doc/html/rfc6901
 public struct JSONPointer: Sendable, Hashable {
@@ -73,6 +75,13 @@ public struct JSONPointer: Sendable, Hashable {
     }
 
     return JSONPointer(path: Array(path.dropFirst(base.path.count)))
+  }
+
+  func absoluteLocation(relativeTo baseURL: URL) -> String? {
+    let base = baseURL.withoutFragment ?? baseURL
+    var components = URLComponents(url: base, resolvingAgainstBaseURL: true)
+    components?.fragment = jsonPointerString
+    return components?.url?.absoluteString
   }
 }
 

--- a/Sources/JSONSchema/Pointers/JSONPointer.swift
+++ b/Sources/JSONSchema/Pointers/JSONPointer.swift
@@ -105,8 +105,26 @@ extension JSONPointer {
 }
 
 extension JSONPointer: CustomStringConvertible, CustomDebugStringConvertible {
+  /// A JSON Pointer string as defined by RFC 6901 (no leading `#`).
+  public var jsonPointerString: String {
+    guard path.isEmpty == false else { return "" }
+
+    return path.reduce(into: "") { partialResult, component in
+      partialResult += "/"
+      switch component {
+      case .index(let int):
+        partialResult += String(int)
+      case .key(let string):
+        partialResult +=
+          string
+          .replacingOccurrences(of: "~", with: "~0")
+          .replacingOccurrences(of: "/", with: "~1")
+      }
+    }
+  }
+
   public var description: String {
-    JSONPointer.fragment(fromEncodedTokens: path.map { $0.encodedFragment })
+    "#" + jsonPointerString
   }
 
   public var debugDescription: String { description }
@@ -132,7 +150,7 @@ extension JSONPointer: Codable {
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
-    try container.encode(description)
+    try container.encode(jsonPointerString)
   }
 }
 

--- a/Sources/JSONSchema/Pointers/JSONPointer.swift
+++ b/Sources/JSONSchema/Pointers/JSONPointer.swift
@@ -83,11 +83,11 @@ public struct JSONPointer: Sendable, Hashable {
     return JSONPointer(path: Array(path.dropFirst(base.path.count)))
   }
 
-  func absoluteLocation(relativeTo baseURL: URL) -> String? {
+  func absoluteLocation(relativeTo baseURL: URL) -> URL? {
     let base = baseURL.withoutFragment ?? baseURL
     var components = URLComponents(url: base, resolvingAgainstBaseURL: true)
     components?.fragment = jsonPointerString
-    return components?.url?.absoluteString
+    return components?.url
   }
 }
 

--- a/Sources/JSONSchema/Schema+Codable.swift
+++ b/Sources/JSONSchema/Schema+Codable.swift
@@ -1,11 +1,23 @@
+import Foundation
+
 extension Schema: Codable {
   public init(from decoder: any Decoder) throws {
     let container = try decoder.singleValueContainer()
 
     if let bool = try? container.decode(BooleanSchema.self) {
-      self.init(schema: bool, location: .init(), context: Context(dialect: .draft2020_12))
+      self.init(
+        schema: bool,
+        location: .init(),
+        context: Context(dialect: .draft2020_12),
+        documentURL: URL(fileURLWithPath: #file)
+      )
     } else if let schema = try? container.decode(ObjectSchema.self) {
-      self.init(schema: schema, location: .init(), context: Context(dialect: .draft2020_12))
+      self.init(
+        schema: schema,
+        location: .init(),
+        context: Context(dialect: .draft2020_12),
+        documentURL: URL(fileURLWithPath: #file)
+      )
     } else {
       throw DecodingError.dataCorruptedError(
         in: container,
@@ -35,7 +47,12 @@ extension BooleanSchema: Codable {
   public init(from decoder: any Decoder) throws {
     let container = try decoder.singleValueContainer()
     let bool = try container.decode(Bool.self)
-    self.init(schemaValue: bool, location: .init(), context: Context(dialect: .draft2020_12))
+    self.init(
+      schemaValue: bool,
+      location: .init(),
+      context: Context(dialect: .draft2020_12),
+      documentURL: URL(fileURLWithPath: #file)
+    )
   }
 
   public func encode(to encoder: any Encoder) throws {

--- a/Sources/JSONSchema/Schema.swift
+++ b/Sources/JSONSchema/Schema.swift
@@ -33,7 +33,8 @@ public struct Schema: ValidatableSchema {
       self.schema = BooleanSchema(
         schemaValue: boolValue,
         location: location,
-        context: context
+        context: context,
+        documentURL: documentURL
       )
     case .object(let schemaDict):
       self.schema = try ObjectSchema(
@@ -126,17 +127,25 @@ package struct BooleanSchema: ValidatableSchema {
   let schemaValue: Bool
   let location: JSONPointer
   let context: Context
+  let documentURL: URL
 
-  package init(schemaValue: Bool, location: JSONPointer, context: Context) {
+  package init(
+    schemaValue: Bool,
+    location: JSONPointer,
+    context: Context,
+    documentURL: URL = URL(fileURLWithPath: #file)
+  ) {
     self.schemaValue = schemaValue
     self.location = location
     self.context = context
+    self.documentURL = documentURL
   }
 
   package func validate(_ instance: JSONValue, at location: JSONPointer) -> ValidationResult {
     ValidationResult(
       valid: schemaValue,
       keywordLocation: self.location,
+      absoluteKeywordLocation: self.location.absoluteLocation(relativeTo: documentURL),
       instanceLocation: location,
       errors: schemaValue
         ? []
@@ -145,6 +154,7 @@ package struct BooleanSchema: ValidatableSchema {
             keyword: "boolean",
             message: "",
             keywordLocation: self.location,
+            absoluteKeywordLocation: self.location.absoluteLocation(relativeTo: documentURL),
             instanceLocation: location
           )
         ]
@@ -152,7 +162,7 @@ package struct BooleanSchema: ValidatableSchema {
   }
 
   package func asSchema() -> Schema {
-    .init(schema: self, location: location, context: context)
+    .init(schema: self, location: location, context: context, documentURL: documentURL)
   }
 }
 
@@ -352,6 +362,8 @@ package struct ObjectSchema: ValidatableSchema {
           try applicator.validate(instance, at: location, using: &annotations)
         case let assertion as any AssertionKeyword:
           try assertion.validate(instance, at: location, using: annotations)
+        case let metadata as any MetadataKeyword:
+          metadata.recordAnnotation(at: location, using: &annotations)
         default:
           continue
         }
@@ -360,6 +372,7 @@ package struct ObjectSchema: ValidatableSchema {
         let validationError = error.makeValidationError(
           keyword: keywordName,
           keywordLocation: self.location.appending(.key(keywordName)),
+          absoluteKeywordLocation: absoluteKeywordLocation(for: keywordName),
           instanceLocation: location
         )
         errors.append(validationError)
@@ -371,6 +384,7 @@ package struct ObjectSchema: ValidatableSchema {
     return ValidationResult(
       valid: errors.isEmpty,
       keywordLocation: self.location,
+      absoluteKeywordLocation: absoluteKeywordLocation(forPointer: self.location),
       instanceLocation: location,
       errors: errors.isEmpty ? nil : errors,
       annotations: collectedAnnotations.isEmpty ? nil : collectedAnnotations
@@ -378,6 +392,19 @@ package struct ObjectSchema: ValidatableSchema {
   }
 
   package func asSchema() -> Schema {
-    .init(schema: self, location: location, context: context)
+    .init(schema: self, location: location, context: context, documentURL: documentURL)
+  }
+
+  private func baseURIForAbsoluteLocation() -> URL {
+    uri ?? documentURL
+  }
+
+  private func absoluteKeywordLocation(for keywordName: String) -> String? {
+    let pointer = self.location.appending(.key(keywordName))
+    return absoluteKeywordLocation(forPointer: pointer)
+  }
+
+  private func absoluteKeywordLocation(forPointer pointer: JSONPointer) -> String? {
+    pointer.absoluteLocation(relativeTo: baseURIForAbsoluteLocation())
   }
 }

--- a/Sources/JSONSchema/Schema.swift
+++ b/Sources/JSONSchema/Schema.swift
@@ -399,12 +399,12 @@ package struct ObjectSchema: ValidatableSchema {
     uri ?? documentURL
   }
 
-  private func absoluteKeywordLocation(for keywordName: String) -> String? {
+  private func absoluteKeywordLocation(for keywordName: String) -> URL? {
     let pointer = self.location.appending(.key(keywordName))
     return absoluteKeywordLocation(forPointer: pointer)
   }
 
-  private func absoluteKeywordLocation(forPointer pointer: JSONPointer) -> String? {
+  private func absoluteKeywordLocation(forPointer pointer: JSONPointer) -> URL? {
     pointer.absoluteLocation(relativeTo: baseURIForAbsoluteLocation())
   }
 }

--- a/Sources/JSONSchema/Schema.swift
+++ b/Sources/JSONSchema/Schema.swift
@@ -142,10 +142,11 @@ package struct BooleanSchema: ValidatableSchema {
   }
 
   package func validate(_ instance: JSONValue, at location: JSONPointer) -> ValidationResult {
-    ValidationResult(
+    let absoluteLocation = self.location.absoluteLocation(relativeTo: documentURL)
+    return ValidationResult(
       valid: schemaValue,
       keywordLocation: self.location,
-      absoluteKeywordLocation: self.location.absoluteLocation(relativeTo: documentURL),
+      absoluteKeywordLocation: absoluteLocation,
       instanceLocation: location,
       errors: schemaValue
         ? []
@@ -154,7 +155,7 @@ package struct BooleanSchema: ValidatableSchema {
             keyword: "boolean",
             message: "",
             keywordLocation: self.location,
-            absoluteKeywordLocation: self.location.absoluteLocation(relativeTo: documentURL),
+            absoluteKeywordLocation: absoluteLocation,
             instanceLocation: location
           )
         ]

--- a/Sources/JSONSchema/Validation/Errors/ValidationIssue.swift
+++ b/Sources/JSONSchema/Validation/Errors/ValidationIssue.swift
@@ -56,6 +56,7 @@ extension ValidationIssue {
   func makeValidationError(
     keyword: String,
     keywordLocation: JSONPointer,
+    absoluteKeywordLocation: String?,
     instanceLocation: JSONPointer
   ) -> ValidationError {
     switch self {
@@ -64,6 +65,7 @@ extension ValidationIssue {
         keyword: keyword,
         message: "Validation failed for keyword '\(keyword)'",
         keywordLocation: keywordLocation,
+        absoluteKeywordLocation: absoluteKeywordLocation,
         instanceLocation: instanceLocation,
         errors: errors
       )
@@ -72,6 +74,7 @@ extension ValidationIssue {
         keyword: keyword,
         message: "Validation failed during reference validation '\(ref)'",
         keywordLocation: keywordLocation,
+        absoluteKeywordLocation: absoluteKeywordLocation,
         instanceLocation: instanceLocation,
         errors: errors
       )
@@ -80,6 +83,7 @@ extension ValidationIssue {
         keyword: keyword,
         message: description,
         keywordLocation: keywordLocation,
+        absoluteKeywordLocation: absoluteKeywordLocation,
         instanceLocation: instanceLocation
       )
     }

--- a/Sources/JSONSchema/Validation/Errors/ValidationIssue.swift
+++ b/Sources/JSONSchema/Validation/Errors/ValidationIssue.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public enum ValidationIssue: Error, Codable, Equatable {
   case typeMismatch(expected: [JSONType], actual: JSONType)
   case notEnumCase(value: JSONValue, allowedValues: [JSONValue])
@@ -56,7 +58,7 @@ extension ValidationIssue {
   func makeValidationError(
     keyword: String,
     keywordLocation: JSONPointer,
-    absoluteKeywordLocation: String?,
+    absoluteKeywordLocation: URL?,
     instanceLocation: JSONPointer
   ) -> ValidationError {
     switch self {

--- a/Sources/JSONSchema/Validation/ValidatableSchema.swift
+++ b/Sources/JSONSchema/Validation/ValidatableSchema.swift
@@ -18,4 +18,25 @@ extension ValidatableSchema {
     let data = try decoder.decode(JSONValue.self, from: Data(instance.utf8))
     return validate(data, at: location)
   }
+
+  /// Validates the instance and renders the result into a spec-compliant validation output document.
+  public func validate(
+    _ instance: JSONValue,
+    at location: JSONPointer = .init(),
+    output configuration: ValidationOutputConfiguration
+  ) throws -> JSONValue {
+    let result = validate(instance, at: location)
+    return try result.renderedOutput(configuration: configuration)
+  }
+
+  /// Convenience for producing validation outputs from `String` instances.
+  public func validate(
+    instance: String,
+    using decoder: JSONDecoder = .init(),
+    at location: JSONPointer = .init(),
+    output configuration: ValidationOutputConfiguration
+  ) throws -> JSONValue {
+    let data = try decoder.decode(JSONValue.self, from: Data(instance.utf8))
+    return try validate(data, at: location, output: configuration)
+  }
 }

--- a/Sources/JSONSchema/Validation/ValidationOutput.swift
+++ b/Sources/JSONSchema/Validation/ValidationOutput.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+public enum ValidationOutputLevel {
+  case flag
+  case basic
+}
+
+private struct ValidationOutputUnit: Encodable {
+  let valid: Bool
+  let keywordLocation: String
+  let absoluteKeywordLocation: String?
+  let instanceLocation: String
+  let error: String?
+  let errors: [ValidationOutputUnit]?
+  let annotations: [AnyAnnotationWrapper]?
+
+  static func make(from result: ValidationResult) -> ValidationOutputUnit {
+    ValidationOutputUnit(
+      valid: result.isValid,
+      keywordLocation: result.keywordLocation.jsonPointerString,
+      absoluteKeywordLocation: result.absoluteKeywordLocation,
+      instanceLocation: result.instanceLocation.jsonPointerString,
+      error: nil,
+      errors: flatten(errors: result.errors),
+      annotations: result.isValid
+        ? result.annotations?.map { AnyAnnotationWrapper(annotation: $0) }
+        : nil
+    )
+  }
+
+  static func flatten(errors: [ValidationError]?) -> [ValidationOutputUnit]? {
+    guard let errors else { return nil }
+
+    var flattened: [ValidationOutputUnit] = []
+    for error in errors {
+      if let nested = error.errors, !nested.isEmpty {
+        if let nestedFlattened = flatten(errors: nested) {
+          flattened.append(contentsOf: nestedFlattened)
+        }
+      } else {
+        flattened.append(
+          ValidationOutputUnit(
+            valid: false,
+            keywordLocation: error.keywordLocation.jsonPointerString,
+            absoluteKeywordLocation: error.absoluteKeywordLocation,
+            instanceLocation: error.instanceLocation.jsonPointerString,
+            error: error.message,
+            errors: nil,
+            annotations: nil
+          )
+        )
+      }
+    }
+
+    return flattened.isEmpty ? nil : flattened
+  }
+
+  static func jsonValue(from unit: ValidationOutputUnit) throws -> JSONValue {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let data = try encoder.encode(unit)
+    return try JSONDecoder().decode(JSONValue.self, from: data)
+  }
+}
+
+extension ValidationResult {
+  public func renderedOutput(level: ValidationOutputLevel) throws -> JSONValue {
+    switch level {
+    case .flag:
+      return .boolean(isValid)
+    case .basic:
+      return try ValidationOutputUnit.jsonValue(from: .make(from: self))
+    }
+  }
+}

--- a/Sources/JSONSchema/Validation/ValidationOutput.swift
+++ b/Sources/JSONSchema/Validation/ValidationOutput.swift
@@ -1,8 +1,22 @@
 import Foundation
 
-public enum ValidationOutputLevel {
+public enum ValidationOutputLevel: Sendable {
   case flag
   case basic
+}
+
+public struct ValidationOutputConfiguration: Sendable, Equatable {
+  public var level: ValidationOutputLevel
+
+  public init(level: ValidationOutputLevel) {
+    self.level = level
+  }
+
+  /// Convenience for producing the spec's "flag" level output, which is a boolean result.
+  public static let flag = ValidationOutputConfiguration(level: .flag)
+
+  /// Convenience for producing the spec's "basic" level output, which is a single result object.
+  public static let basic = ValidationOutputConfiguration(level: .basic)
 }
 
 private struct ValidationOutputUnit: Encodable {
@@ -71,5 +85,9 @@ extension ValidationResult {
     case .basic:
       return try ValidationOutputUnit.jsonValue(from: .make(from: self))
     }
+  }
+
+  public func renderedOutput(configuration: ValidationOutputConfiguration) throws -> JSONValue {
+    try renderedOutput(level: configuration.level)
   }
 }

--- a/Sources/JSONSchema/Validation/ValidationOutput.swift
+++ b/Sources/JSONSchema/Validation/ValidationOutput.swift
@@ -30,7 +30,7 @@ public struct ValidationOutputConfiguration: Sendable, Equatable {
 private struct ValidationOutputUnit: Encodable {
   let valid: Bool
   let keywordLocation: String
-  let absoluteKeywordLocation: String?
+  let absoluteKeywordLocation: URL?
   let instanceLocation: String
   let error: String?
   let errors: [ValidationOutputUnit]?

--- a/Sources/JSONSchema/Validation/ValidationResult.swift
+++ b/Sources/JSONSchema/Validation/ValidationResult.swift
@@ -9,7 +9,7 @@ public struct ValidationResult: Sendable, Encodable, Equatable {
   init(
     valid: Bool,
     keywordLocation: JSONPointer,
-    absoluteKeywordLocation: String?,
+    absoluteKeywordLocation: String? = nil,
     instanceLocation: JSONPointer,
     errors: [ValidationError]? = nil,
     annotations: [AnyAnnotation]? = nil
@@ -38,13 +38,10 @@ public struct ValidationResult: Sendable, Encodable, Equatable {
     try container.encodeIfPresent(absoluteKeywordLocation, forKey: .absoluteKeywordLocation)
     try container.encode(instanceLocation, forKey: .instanceLocation)
     try container.encodeIfPresent(errors, forKey: .errors)
-    if isValid,
-      let annotations,
-      !annotations.isEmpty
-    {
-      let wrapped = annotations.map { AnyAnnotationWrapper(annotation: $0) }
-      try container.encode(wrapped, forKey: .annotations)
-    }
+    try container.encodeIfPresent(
+      annotations?.map { AnyAnnotationWrapper(annotation: $0) },
+      forKey: .annotations
+    )
   }
 
   public static func == (lhs: ValidationResult, rhs: ValidationResult) -> Bool {
@@ -68,7 +65,7 @@ public struct ValidationError: Sendable, Codable, Equatable {
     keyword: String,
     message: String,
     keywordLocation: JSONPointer,
-    absoluteKeywordLocation: String?,
+    absoluteKeywordLocation: String? = nil,
     instanceLocation: JSONPointer,
     errors: [ValidationError]? = nil
   ) {

--- a/Sources/JSONSchema/Validation/ValidationResult.swift
+++ b/Sources/JSONSchema/Validation/ValidationResult.swift
@@ -1,7 +1,9 @@
+import Foundation
+
 public struct ValidationResult: Sendable, Encodable, Equatable {
   public let isValid: Bool
   public let keywordLocation: JSONPointer
-  public let absoluteKeywordLocation: String?
+  public let absoluteKeywordLocation: URL?
   public let instanceLocation: JSONPointer
   public let errors: [ValidationError]?
   public let annotations: [AnyAnnotation]?
@@ -9,7 +11,7 @@ public struct ValidationResult: Sendable, Encodable, Equatable {
   init(
     valid: Bool,
     keywordLocation: JSONPointer,
-    absoluteKeywordLocation: String? = nil,
+    absoluteKeywordLocation: URL? = nil,
     instanceLocation: JSONPointer,
     errors: [ValidationError]? = nil,
     annotations: [AnyAnnotation]? = nil
@@ -57,7 +59,7 @@ public struct ValidationError: Sendable, Codable, Equatable {
   public let keyword: String
   public let message: String
   public let keywordLocation: JSONPointer
-  public let absoluteKeywordLocation: String?
+  public let absoluteKeywordLocation: URL?
   public let instanceLocation: JSONPointer
   public let errors: [ValidationError]?  // For nested errors
 
@@ -65,7 +67,7 @@ public struct ValidationError: Sendable, Codable, Equatable {
     keyword: String,
     message: String,
     keywordLocation: JSONPointer,
-    absoluteKeywordLocation: String? = nil,
+    absoluteKeywordLocation: URL? = nil,
     instanceLocation: JSONPointer,
     errors: [ValidationError]? = nil
   ) {

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent.swift
@@ -75,7 +75,7 @@ extension JSONSchemaComponent {
   }
 }
 
-public enum ParseAndValidateIssue: Error {
+public indirect enum ParseAndValidateIssue: Error {
   case decodingFailed(Error)
   case parsingFailed([ParseIssue])
   case validationFailed(ValidationResult)

--- a/Tests/JSONSchemaTests/JSONSchemaTestSuite.swift
+++ b/Tests/JSONSchemaTests/JSONSchemaTestSuite.swift
@@ -113,28 +113,35 @@ extension JSONSchemaTest: CustomTestStringConvertible {
 }
 
 extension Encodable {
-  fileprivate func toJsonString() throws -> String {
+  func toJsonString() throws -> String {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     let data = try encoder.encode(self)
     return String(decoding: data, as: UTF8.self)
   }
+
+  func toJSONValue() throws -> JSONValue {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let data = try encoder.encode(self)
+    return try JSONDecoder().decode(JSONValue.self, from: data)
+  }
 }
 
 extension Schema {
-  fileprivate func json() throws -> String {
+  func json() throws -> String {
     try toJsonString()
   }
 }
 
 extension JSONValue {
-  fileprivate func json() throws -> String {
+  func json() throws -> String {
     try toJsonString()
   }
 }
 
 extension ValidationResult {
-  fileprivate func json() throws -> String {
+  func json() throws -> String {
     try toJsonString()
   }
 }

--- a/Tests/JSONSchemaTests/JSONSchemaTestSuite.swift
+++ b/Tests/JSONSchemaTests/JSONSchemaTestSuite.swift
@@ -113,7 +113,7 @@ extension JSONSchemaTest: CustomTestStringConvertible {
 }
 
 extension Encodable {
-  func toJsonString() throws -> String {
+  func toJSONString() throws -> String {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     let data = try encoder.encode(self)
@@ -130,18 +130,18 @@ extension Encodable {
 
 extension Schema {
   func json() throws -> String {
-    try toJsonString()
+    try toJSONString()
   }
 }
 
 extension JSONValue {
   func json() throws -> String {
-    try toJsonString()
+    try toJSONString()
   }
 }
 
 extension ValidationResult {
   func json() throws -> String {
-    try toJsonString()
+    try toJSONString()
   }
 }

--- a/Tests/JSONSchemaTests/JSONSchemaTestSuite.swift
+++ b/Tests/JSONSchemaTests/JSONSchemaTestSuite.swift
@@ -127,7 +127,7 @@ extension JSONSchemaTest: CustomTestStringConvertible {
 }
 
 extension Encodable {
-  func toJsonString() throws -> String {
+  func toJSONString() throws -> String {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     let data = try encoder.encode(self)
@@ -144,18 +144,18 @@ extension Encodable {
 
 extension Schema {
   func json() throws -> String {
-    try toJsonString()
+    try toJSONString()
   }
 }
 
 extension JSONValue {
   func json() throws -> String {
-    try toJsonString()
+    try toJSONString()
   }
 }
 
 extension ValidationResult {
   func json() throws -> String {
-    try toJsonString()
+    try toJSONString()
   }
 }

--- a/Tests/JSONSchemaTests/JSONSchemaTestSuite.swift
+++ b/Tests/JSONSchemaTests/JSONSchemaTestSuite.swift
@@ -127,28 +127,35 @@ extension JSONSchemaTest: CustomTestStringConvertible {
 }
 
 extension Encodable {
-  fileprivate func toJsonString() throws -> String {
+  func toJsonString() throws -> String {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     let data = try encoder.encode(self)
     return String(decoding: data, as: UTF8.self)
   }
+
+  func toJSONValue() throws -> JSONValue {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let data = try encoder.encode(self)
+    return try JSONDecoder().decode(JSONValue.self, from: data)
+  }
 }
 
 extension Schema {
-  fileprivate func json() throws -> String {
+  func json() throws -> String {
     try toJsonString()
   }
 }
 
 extension JSONValue {
-  fileprivate func json() throws -> String {
+  func json() throws -> String {
     try toJsonString()
   }
 }
 
 extension ValidationResult {
-  fileprivate func json() throws -> String {
+  func json() throws -> String {
     try toJsonString()
   }
 }

--- a/Tests/JSONSchemaTests/OutputTestSuite.swift
+++ b/Tests/JSONSchemaTests/OutputTestSuite.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+
+@testable import JSONSchema
+
+struct OutputTestSuite {
+  private static let supportedFormats: Set<String> = ["basic"]
+
+  static let fileLoader = FileLoader<[OutputTestDocument]>(
+    subdirectory: "JSON-Schema-Test-Suite/output-tests/draft2020-12/content"
+  )
+
+  static let flattenedArguments: [(testCase: OutputTestDocument, path: URL)] = {
+    fileLoader.loadAllFiles()
+      .flatMap { path, documents in
+        documents.map { ($0, path) }
+      }
+  }()
+
+  static let remotes: [String: JSONValue] = RemoteLoader().loadSchemas()
+
+  @Test(arguments: flattenedArguments)
+  func outputTest(_ testDocument: OutputTestDocument, path: URL) throws {
+    let schema = try Schema(
+      rawSchema: testDocument.schema,
+      context: .init(dialect: .draft2020_12, remoteSchema: Self.remotes),
+      baseURI: path
+    )
+
+    for test in testDocument.tests {
+      let validationResult = schema.validate(test.data)
+      let validationValue = try validationResult.toJSONValue()
+
+      for (format, outputSchemaJSON) in test.output {
+        guard Self.supportedFormats.contains(format) else { continue }
+
+        let outputSchema = try Schema(
+          rawSchema: outputSchemaJSON,
+          context: .init(dialect: .draft2020_12, remoteSchema: Self.remotes),
+          baseURI: path
+        )
+
+        let outputValidation = outputSchema.validate(validationValue)
+
+        let comment: () -> Testing.Comment = {
+          """
+          Output Test: \"\(testDocument.description)\" @ \(path)
+          Format: \(format)
+          ```json
+          \(try! testDocument.schema.json())
+          ```
+
+          Test Case: \"\(test.description)\"
+          ```json
+          \(try! test.data.json())
+          ```
+
+          Output:
+          ```json
+          \(try! validationResult.json())
+          ```
+          """
+        }
+
+        #expect(outputValidation.isValid, comment())
+      }
+    }
+  }
+}
+
+struct OutputTestDocument: Sendable, Codable {
+  struct TestCase: Sendable, Codable {
+    let description: String
+    let comment: String?
+    let data: JSONValue
+    let output: [String: JSONValue]
+  }
+
+  let description: String
+  let comment: String?
+  let schema: JSONValue
+  let tests: [TestCase]
+}

--- a/Tests/JSONSchemaTests/OutputTestSuite.swift
+++ b/Tests/JSONSchemaTests/OutputTestSuite.swift
@@ -29,7 +29,7 @@ struct OutputTestSuite {
 
     for test in testDocument.tests {
       let validationResult = schema.validate(test.data)
-      let validationValue = try validationResult.toJSONValue()
+      let validationValue = try validationResult.renderedOutput(level: .basic)
 
       for (format, outputSchemaJSON) in test.output {
         guard Self.supportedFormats.contains(format) else { continue }

--- a/Tests/JSONSchemaTests/SchemaTests.swift
+++ b/Tests/JSONSchemaTests/SchemaTests.swift
@@ -232,4 +232,68 @@ struct SchemaTests {
     let result = schema.validate(["foo": ["type": 1]])
     #expect(result.isValid == false, "\(result)")
   }
+
+  @Test func absoluteKeywordLocationLocalRef() throws {
+    let baseURL = try #require(URL(string: "https://example.com/schemas/root"))
+    let rawSchema: JSONValue = [
+      "$id": JSONValue.string(baseURL.absoluteString),
+      "$defs": [
+        "nonEmpty": [
+          "type": "string",
+          "minLength": 2,
+        ]
+      ],
+      "allOf": [
+        ["$ref": "#/$defs/nonEmpty"]
+      ],
+    ]
+
+    let schema = try Schema(
+      rawSchema: rawSchema,
+      context: Context(dialect: .draft2020_12),
+      baseURI: baseURL
+    )
+
+    let result = schema.validate(.string(""))
+    let allOfError = try #require(result.errors?.first)
+    #expect(allOfError.keywordLocation == JSONPointer(tokens: ["allOf"]))
+
+    let referenceFailure = try #require(allOfError.errors?.first)
+    #expect(referenceFailure.keywordLocation == JSONPointer(tokens: ["allOf", "0", "$ref"]))
+
+    let dereferencedError = try #require(referenceFailure.errors?.first)
+    #expect(
+      dereferencedError.keywordLocation
+        == JSONPointer(tokens: ["allOf", "0", "$ref", "minLength"])
+    )
+    #expect(
+      dereferencedError.absoluteKeywordLocation
+        == "https://example.com/schemas/root#/$defs/nonEmpty/minLength"
+    )
+  }
+
+  @Test func absoluteKeywordLocationRemoteRef() throws {
+    let remoteURL = "https://example.com/strings.json"
+    let remoteSchema: JSONValue = [
+      "$id": JSONValue.string(remoteURL),
+      "type": "string",
+      "minLength": 5,
+    ]
+
+    let schema = try Schema(
+      rawSchema: ["$ref": JSONValue.string(remoteURL)],
+      context: Context(dialect: .draft2020_12, remoteSchema: [remoteURL: remoteSchema]),
+      baseURI: URL(string: "https://example.com/root.json")!
+    )
+
+    let result = schema.validate(JSONValue.string("abc"))
+    let refError = try #require(result.errors?.first)
+
+    let dereferencedError = try #require(refError.errors?.first)
+    #expect(dereferencedError.keywordLocation == JSONPointer(tokens: ["$ref", "minLength"]))
+    #expect(
+      dereferencedError.absoluteKeywordLocation
+        == "https://example.com/strings.json#/minLength"
+    )
+  }
 }

--- a/Tests/JSONSchemaTests/SchemaTests.swift
+++ b/Tests/JSONSchemaTests/SchemaTests.swift
@@ -104,6 +104,19 @@ struct SchemaTests {
     #expect(result.annotations == nil)
   }
 
+  @Test func validationOutputAPI() throws {
+    let trueSchema = try Schema(rawSchema: .boolean(true), context: .init(dialect: .draft2020_12))
+    let basicOutput = try trueSchema.validate(.string("ok"), output: .basic)
+    let outputObject = try #require(basicOutput.object)
+    #expect(outputObject["valid"] == .boolean(true))
+    #expect(outputObject["keywordLocation"] == .string(""))
+    #expect(outputObject["instanceLocation"] == .string(""))
+
+    let falseSchema = try Schema(rawSchema: .boolean(false), context: .init(dialect: .draft2020_12))
+    let flagOutput = try falseSchema.validate(.string("ok"), output: .flag)
+    #expect(flagOutput == .boolean(false))
+  }
+
   @Test func metaSchema() throws {
     let metaSchema = try Dialect.draft2020_12.loadMetaSchema()
     let result = metaSchema.validate(.object(["minLength": 1]))

--- a/Tests/JSONSchemaTests/SchemaTests.swift
+++ b/Tests/JSONSchemaTests/SchemaTests.swift
@@ -231,4 +231,68 @@ struct SchemaTests {
     let result = schema.validate(["foo": ["type": 1]])
     #expect(result.isValid == false, "\(result)")
   }
+
+  @Test func absoluteKeywordLocationLocalRef() throws {
+    let baseURL = try #require(URL(string: "https://example.com/schemas/root"))
+    let rawSchema: JSONValue = [
+      "$id": JSONValue.string(baseURL.absoluteString),
+      "$defs": [
+        "nonEmpty": [
+          "type": "string",
+          "minLength": 2,
+        ]
+      ],
+      "allOf": [
+        ["$ref": "#/$defs/nonEmpty"]
+      ],
+    ]
+
+    let schema = try Schema(
+      rawSchema: rawSchema,
+      context: Context(dialect: .draft2020_12),
+      baseURI: baseURL
+    )
+
+    let result = schema.validate(.string(""))
+    let allOfError = try #require(result.errors?.first)
+    #expect(allOfError.keywordLocation == JSONPointer(tokens: ["allOf"]))
+
+    let referenceFailure = try #require(allOfError.errors?.first)
+    #expect(referenceFailure.keywordLocation == JSONPointer(tokens: ["allOf", "0", "$ref"]))
+
+    let dereferencedError = try #require(referenceFailure.errors?.first)
+    #expect(
+      dereferencedError.keywordLocation
+        == JSONPointer(tokens: ["allOf", "0", "$ref", "minLength"])
+    )
+    #expect(
+      dereferencedError.absoluteKeywordLocation
+        == "https://example.com/schemas/root#/$defs/nonEmpty/minLength"
+    )
+  }
+
+  @Test func absoluteKeywordLocationRemoteRef() throws {
+    let remoteURL = "https://example.com/strings.json"
+    let remoteSchema: JSONValue = [
+      "$id": JSONValue.string(remoteURL),
+      "type": "string",
+      "minLength": 5,
+    ]
+
+    let schema = try Schema(
+      rawSchema: ["$ref": JSONValue.string(remoteURL)],
+      context: Context(dialect: .draft2020_12, remoteSchema: [remoteURL: remoteSchema]),
+      baseURI: URL(string: "https://example.com/root.json")!
+    )
+
+    let result = schema.validate(JSONValue.string("abc"))
+    let refError = try #require(result.errors?.first)
+
+    let dereferencedError = try #require(refError.errors?.first)
+    #expect(dereferencedError.keywordLocation == JSONPointer(tokens: ["$ref", "minLength"]))
+    #expect(
+      dereferencedError.absoluteKeywordLocation
+        == "https://example.com/strings.json#/minLength"
+    )
+  }
 }

--- a/Tests/JSONSchemaTests/SchemaTests.swift
+++ b/Tests/JSONSchemaTests/SchemaTests.swift
@@ -267,7 +267,7 @@ struct SchemaTests {
     )
     #expect(
       dereferencedError.absoluteKeywordLocation
-        == "https://example.com/schemas/root#/$defs/nonEmpty/minLength"
+        == URL(string: "https://example.com/schemas/root#/$defs/nonEmpty/minLength")
     )
   }
 
@@ -292,7 +292,7 @@ struct SchemaTests {
     #expect(dereferencedError.keywordLocation == JSONPointer(tokens: ["$ref", "minLength"]))
     #expect(
       dereferencedError.absoluteKeywordLocation
-        == "https://example.com/strings.json#/minLength"
+        == URL(string: "https://example.com/strings.json#/minLength")
     )
   }
 }

--- a/Tests/JSONSchemaTests/SchemaTests.swift
+++ b/Tests/JSONSchemaTests/SchemaTests.swift
@@ -271,6 +271,58 @@ struct SchemaTests {
     )
   }
 
+  @Test func chainedRefKeywordLocations() throws {
+    let baseURL = try #require(URL(string: "https://example.com/chained"))
+    let rawSchema: JSONValue = [
+      "$id": JSONValue.string(baseURL.absoluteString),
+      "$defs": [
+        "A": ["$ref": "#/$defs/B"],
+        "B": ["type": "integer"],
+      ],
+      "properties": [
+        "x": ["$ref": "#/$defs/A"]
+      ],
+    ]
+
+    let schema = try Schema(
+      rawSchema: rawSchema,
+      context: Context(dialect: .draft2020_12),
+      baseURI: baseURL
+    )
+
+    let result = schema.validate(["x": "wrong"])
+    #expect(result.isValid == false)
+
+    let propertiesError = try #require(result.errors?.first)
+    #expect(propertiesError.keywordLocation == JSONPointer(tokens: ["properties"]))
+
+    let outerRefError = try #require(propertiesError.errors?.first)
+    #expect(
+      outerRefError.keywordLocation == JSONPointer(tokens: ["properties", "x", "$ref"])
+    )
+
+    // The inner $ref's location must be re-rooted under the outer $ref, not pasted at root.
+    let innerRefError = try #require(outerRefError.errors?.first)
+    #expect(
+      innerRefError.keywordLocation
+        == JSONPointer(tokens: ["properties", "x", "$ref", "$ref"])
+    )
+    #expect(
+      innerRefError.absoluteKeywordLocation
+        == URL(string: "https://example.com/chained#/$defs/A/$ref")
+    )
+
+    let typeError = try #require(innerRefError.errors?.first)
+    #expect(
+      typeError.keywordLocation
+        == JSONPointer(tokens: ["properties", "x", "$ref", "$ref", "type"])
+    )
+    #expect(
+      typeError.absoluteKeywordLocation
+        == URL(string: "https://example.com/chained#/$defs/B/type")
+    )
+  }
+
   @Test func absoluteKeywordLocationRemoteRef() throws {
     let remoteURL = "https://example.com/strings.json"
     let remoteSchema: JSONValue = [

--- a/Tests/JSONSchemaTests/Utils/FileLoader.swift
+++ b/Tests/JSONSchemaTests/Utils/FileLoader.swift
@@ -83,11 +83,42 @@ struct RemoteLoader {
 
   func loadSchemas() -> [String: JSONValue] {
     do {
-      return try fetchRemoteSchemas()
+      var remotes = try fetchRemoteSchemas()
+      let outputSchemas = try fetchOutputSchemas()
+      remotes.merge(outputSchemas) { _, new in new }
+      return remotes
     } catch {
       print("Error: \(error)")
       return [:]
     }
+  }
+
+  private func fetchOutputSchemas() throws -> [String: JSONValue] {
+    guard let resourcesURL = Bundle.module.resourceURL else { return [:] }
+    let outputTestsURL = resourcesURL.appendingPathComponent("JSON-Schema-Test-Suite/output-tests")
+
+    let directoryEnumerator = FileManager.default.enumerator(
+      at: outputTestsURL,
+      includingPropertiesForKeys: [.isDirectoryKey],
+      options: [.skipsHiddenFiles]
+    )
+
+    var discoveredSchemas: [String: JSONValue] = [:]
+
+    while let url = directoryEnumerator?.nextObject() as? URL {
+      guard url.lastPathComponent == "output-schema.json" else { continue }
+
+      let data = try Data(contentsOf: url)
+      let schema = try JSONDecoder().decode(JSONValue.self, from: data)
+
+      if case .object(let object) = schema,
+        case .string(let identifier)? = object["$id"]
+      {
+        discoveredSchemas[identifier] = schema
+      }
+    }
+
+    return discoveredSchemas
   }
 }
 


### PR DESCRIPTION
## Description

- Hooks up `absoluteKeywordLocation` in result
- Supports more levels of validation result
- Adds tests for validation result using JSON Schema Test Suite

Closes #32
Closes #33 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation update

## Additional Notes

Add any other context or screenshots about the pull request here.
