### PR TITLE
Add composition controls for enums and optional nulls

### DIFF
--- a/Sources/JSONSchemaBuilder/Documentation.docc/Articles/Macros.md
+++ b/Sources/JSONSchemaBuilder/Documentation.docc/Articles/Macros.md
@@ -417,6 +417,18 @@ enum TemperatureType {
 
 Notice how unnamed associated values are represented as `_0`, `_1`, etc.
 
+Some consumers (for example, DeepSeek's API) only accept `anyOf` for unions. You can switch the builder that is emitted for associated-value enums by providing the `enumComposition:` argument:
+
+```swift
+@Schemable(enumComposition: .anyOf)
+enum Response {
+  case success(message: String)
+  case failure(code: Int)
+}
+```
+
+This expansion is identical to the previous example except the builder becomes `JSONComposition.AnyOf(into: Response.self)`, keeping the runtime behavior but satisfying downstream constraints.
+
 ### Other Behaviors
 
 #### Default values
@@ -597,8 +609,9 @@ struct User {
 }
 ```
 
-The `.orNull()` modifier supports two styles:
+The `.orNull()` modifier supports three styles:
 - `.type`: Uses type array `["integer", "null"]` - best for scalar primitives, produces clearer validation errors
-- `.union`: Uses oneOf composition - required for complex types (objects, arrays)
+- `.union`: Uses `oneOf` composition - required for complex types (objects, arrays)
+- `.unionAnyOf`: Uses `anyOf` composition - helpful for APIs that forbid `oneOf`.
 
-When `optionalNulls: true` (the default), the appropriate style is automatically selected based on the property type.
+When `optionalNulls: true` (the default), the appropriate style is automatically selected based on the property type. You can influence the composition keyword used for complex types by passing `optionalNullUnion: .anyOf` to `@Schemable`, which will emit `.orNull(style: .unionAnyOf)` for every implicitly-nullable property. This keeps generated schemas compatible with systems (like some LLM APIs) that only support `anyOf`.

--- a/Sources/JSONSchemaBuilder/JSONComponent/Modifier/OrNullModifier.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/Modifier/OrNullModifier.swift
@@ -134,8 +134,8 @@ where Wrapped.Output == WrappedValue {
   }
 }
 
-private extension SchemaComposition {
-  var keywordName: String {
+extension SchemaComposition {
+  fileprivate var keywordName: String {
     switch self {
     case .oneOf:
       return Keywords.OneOf.name

--- a/Sources/JSONSchemaBuilder/Macros/Schemable.swift
+++ b/Sources/JSONSchemaBuilder/Macros/Schemable.swift
@@ -1,8 +1,18 @@
+/// Defines the composition keyword that should be used when combining schemas.
+public enum SchemaComposition {
+  /// Uses the `oneOf` keyword when composing schemas.
+  case oneOf
+  /// Uses the `anyOf` keyword when composing schemas.
+  case anyOf
+}
+
 @attached(extension, conformances: Schemable)
 @attached(member, names: named(schema), named(keyEncodingStrategy))
 public macro Schemable(
   keyStrategy: KeyEncodingStrategies? = nil,
-  optionalNulls: Bool = true
+  optionalNulls: Bool = true,
+  enumComposition: SchemaComposition = .oneOf,
+  optionalNullUnion: SchemaComposition = .oneOf
 ) = #externalMacro(module: "JSONSchemaMacro", type: "SchemableMacro")
 
 public protocol Schemable {

--- a/Sources/JSONSchemaMacro/Schemable/CompositionKeyword.swift
+++ b/Sources/JSONSchemaMacro/Schemable/CompositionKeyword.swift
@@ -1,0 +1,51 @@
+import SwiftSyntax
+
+/// Represents the composition keyword that should be emitted in generated schemas.
+enum CompositionKeyword {
+  case oneOf
+  case anyOf
+
+  init(argument: ExprSyntax?) {
+    guard let argument else {
+      self = .oneOf
+      return
+    }
+
+    if let memberAccess = argument.as(MemberAccessExprSyntax.self) {
+      self = CompositionKeyword(baseName: memberAccess.declName.baseName.text)
+    } else if let declReference = argument.as(DeclReferenceExprSyntax.self) {
+      self = CompositionKeyword(baseName: declReference.baseName.text)
+    } else {
+      self = .oneOf
+    }
+  }
+
+  private init(baseName: String) {
+    switch baseName.lowercased() {
+    case "anyof":
+      self = .anyOf
+    default:
+      self = .oneOf
+    }
+  }
+
+  /// Returns the suffix for `JSONComposition` builders (e.g., `OneOf`).
+  var jsonCompositionBuilderName: String {
+    switch self {
+    case .oneOf:
+      return "OneOf"
+    case .anyOf:
+      return "AnyOf"
+    }
+  }
+
+  /// Returns the member access used when emitting `.orNull(style: ...)`.
+  var orNullStyleAccessor: String {
+    switch self {
+    case .oneOf:
+      return ".union"
+    case .anyOf:
+      return ".unionAnyOf"
+    }
+  }
+}

--- a/Sources/JSONSchemaMacro/Schemable/SchemaGenerator.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SchemaGenerator.swift
@@ -21,7 +21,11 @@ struct EnumSchemaGenerator {
   let isStringBacked: Bool
   let composition: CompositionKeyword
 
-  init(fromEnum enumDecl: EnumDeclSyntax, accessLevel: String? = nil, composition: CompositionKeyword) {
+  init(
+    fromEnum enumDecl: EnumDeclSyntax,
+    accessLevel: String? = nil,
+    composition: CompositionKeyword
+  ) {
     // Use provided access level if available, otherwise use the declaration's modifier
     if let accessLevel {
       // Create modifier with trailing space for proper formatting
@@ -62,7 +66,8 @@ struct EnumSchemaGenerator {
       if !casesWithoutAssociatedValues.isEmpty {
         codeBlockItemList.append(simpleEnumSchema(for: casesWithoutAssociatedValues))
       }
-      codeBlockItem = "JSONComposition.\(raw: composition.jsonCompositionBuilderName)(into: \(name).self) { \(codeBlockItemList) }"
+      codeBlockItem =
+        "JSONComposition.\(raw: composition.jsonCompositionBuilderName)(into: \(name).self) { \(codeBlockItemList) }"
     } else {
       // When no case has an associated value, use simple enum schema
       codeBlockItem = simpleEnumSchema(for: casesWithoutAssociatedValues)

--- a/Sources/JSONSchemaMacro/Schemable/SchemaGenerator.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SchemaGenerator.swift
@@ -19,8 +19,9 @@ struct EnumSchemaGenerator {
   let members: MemberBlockItemListSyntax
   let attributes: AttributeListSyntax
   let isStringBacked: Bool
+  let composition: CompositionKeyword
 
-  init(fromEnum enumDecl: EnumDeclSyntax, accessLevel: String? = nil) {
+  init(fromEnum enumDecl: EnumDeclSyntax, accessLevel: String? = nil, composition: CompositionKeyword) {
     // Use provided access level if available, otherwise use the declaration's modifier
     if let accessLevel {
       // Create modifier with trailing space for proper formatting
@@ -34,6 +35,7 @@ struct EnumSchemaGenerator {
     name = enumDecl.name.trimmed
     members = enumDecl.memberBlock.members
     attributes = enumDecl.attributes
+    self.composition = composition
 
     // Check if enum inherits from String
     isStringBacked =
@@ -60,7 +62,7 @@ struct EnumSchemaGenerator {
       if !casesWithoutAssociatedValues.isEmpty {
         codeBlockItemList.append(simpleEnumSchema(for: casesWithoutAssociatedValues))
       }
-      codeBlockItem = "JSONComposition.OneOf(into: \(name).self) { \(codeBlockItemList) }"
+      codeBlockItem = "JSONComposition.\(raw: composition.jsonCompositionBuilderName)(into: \(name).self) { \(codeBlockItemList) }"
     } else {
       // When no case has an associated value, use simple enum schema
       codeBlockItem = simpleEnumSchema(for: casesWithoutAssociatedValues)
@@ -126,6 +128,7 @@ struct SchemaGenerator {
   let attributes: AttributeListSyntax
   let keyStrategy: ExprSyntax?
   let optionalNulls: Bool
+  let optionalNullUnion: CompositionKeyword
   let context: (any MacroExpansionContext)?
 
   init(
@@ -133,7 +136,8 @@ struct SchemaGenerator {
     keyStrategy: ExprSyntax?,
     optionalNulls: Bool = true,
     accessLevel: String? = nil,
-    context: (any MacroExpansionContext)? = nil
+    context: (any MacroExpansionContext)? = nil,
+    optionalNullUnion: CompositionKeyword
   ) {
     // Use provided access level if available, otherwise use the declaration's modifier
     if let accessLevel {
@@ -151,6 +155,7 @@ struct SchemaGenerator {
     self.keyStrategy = keyStrategy
     self.optionalNulls = optionalNulls
     self.context = context
+    self.optionalNullUnion = optionalNullUnion
   }
 
   init(
@@ -158,7 +163,8 @@ struct SchemaGenerator {
     keyStrategy: ExprSyntax?,
     optionalNulls: Bool = true,
     accessLevel: String? = nil,
-    context: (any MacroExpansionContext)? = nil
+    context: (any MacroExpansionContext)? = nil,
+    optionalNullUnion: CompositionKeyword
   ) {
     // Use provided access level if available, otherwise use the declaration's modifier
     if let accessLevel {
@@ -176,6 +182,7 @@ struct SchemaGenerator {
     self.keyStrategy = keyStrategy
     self.optionalNulls = optionalNulls
     self.context = context
+    self.optionalNullUnion = optionalNullUnion
   }
 
   func makeSchema() -> DeclSyntax {
@@ -207,6 +214,7 @@ struct SchemaGenerator {
         keyStrategy: keyStrategy,
         typeName: name.text,
         globalOptionalNulls: optionalNulls,
+        optionalNullUnion: optionalNullUnion,
         codingKeys: codingKeys,
         context: context,
         selfReferenceAnchor: anchorName,

--- a/Sources/JSONSchemaMacro/Schemable/SchemableMacro.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SchemableMacro.swift
@@ -94,6 +94,9 @@ public struct SchemableMacro: MemberMacro, ExtensionMacro {
       let strategyArg = arguments?.first(where: { $0.label?.text == "keyStrategy" })?.expression
       let optionalNullsArg = arguments?.first(where: { $0.label?.text == "optionalNulls" })?
         .expression
+      let optionalNullUnionArg = arguments?
+        .first(where: { $0.label?.text == "optionalNullUnion" })?
+        .expression
       // Default to true if not specified, otherwise parse the boolean literal
       let optionalNulls: Bool
       if let boolLiteral = optionalNullsArg?.as(BooleanLiteralExprSyntax.self) {
@@ -101,12 +104,14 @@ public struct SchemableMacro: MemberMacro, ExtensionMacro {
       } else {
         optionalNulls = true  // default
       }
+      let optionalNullUnion = CompositionKeyword(argument: optionalNullUnionArg)
       let generator = SchemaGenerator(
         fromStruct: structDecl,
         keyStrategy: strategyArg,
         optionalNulls: optionalNulls,
         accessLevel: accessLevel,
-        context: context
+        context: context,
+        optionalNullUnion: optionalNullUnion
       )
       let schemaDecl = generator.makeSchema()
       var decls: [DeclSyntax] = [schemaDecl]
@@ -124,6 +129,9 @@ public struct SchemableMacro: MemberMacro, ExtensionMacro {
       let strategyArg = arguments?.first(where: { $0.label?.text == "keyStrategy" })?.expression
       let optionalNullsArg = arguments?.first(where: { $0.label?.text == "optionalNulls" })?
         .expression
+      let optionalNullUnionArg = arguments?
+        .first(where: { $0.label?.text == "optionalNullUnion" })?
+        .expression
       // Default to true if not specified, otherwise parse the boolean literal
       let optionalNulls: Bool
       if let boolLiteral = optionalNullsArg?.as(BooleanLiteralExprSyntax.self) {
@@ -131,12 +139,14 @@ public struct SchemableMacro: MemberMacro, ExtensionMacro {
       } else {
         optionalNulls = true  // default
       }
+      let optionalNullUnion = CompositionKeyword(argument: optionalNullUnionArg)
       let generator = SchemaGenerator(
         fromClass: classDecl,
         keyStrategy: strategyArg,
         optionalNulls: optionalNulls,
         accessLevel: accessLevel,
-        context: context
+        context: context,
+        optionalNullUnion: optionalNullUnion
       )
       let schemaDecl = generator.makeSchema()
       var decls: [DeclSyntax] = [schemaDecl]
@@ -150,11 +160,18 @@ public struct SchemableMacro: MemberMacro, ExtensionMacro {
       }
       return decls
     } else if let enumDecl = declaration.as(EnumDeclSyntax.self) {
-      let strategyArg = node.arguments?
-        .as(LabeledExprListSyntax.self)?
+      let arguments = node.arguments?.as(LabeledExprListSyntax.self)
+      let strategyArg = arguments?
         .first(where: { $0.label?.text == "keyStrategy" })?
         .expression
-      let generator = EnumSchemaGenerator(fromEnum: enumDecl, accessLevel: accessLevel)
+      let enumCompositionArg = arguments?
+        .first(where: { $0.label?.text == "enumComposition" })?
+        .expression
+      let generator = EnumSchemaGenerator(
+        fromEnum: enumDecl,
+        accessLevel: accessLevel,
+        composition: CompositionKeyword(argument: enumCompositionArg)
+      )
       let schemaDecl = generator.makeSchema()
       var decls: [DeclSyntax] = [schemaDecl]
 

--- a/Sources/JSONSchemaMacro/Schemable/SchemableMember.swift
+++ b/Sources/JSONSchemaMacro/Schemable/SchemableMember.swift
@@ -79,6 +79,7 @@ struct SchemableMember {
     keyStrategy: ExprSyntax?,
     typeName: String,
     globalOptionalNulls: Bool = true,
+    optionalNullUnion: CompositionKeyword,
     codingKeys: [String: String]? = nil,
     context: (any MacroExpansionContext)? = nil,
     selfReferenceAnchor: String? = nil,
@@ -191,19 +192,19 @@ struct SchemableMember {
           .orNull(style: \(orNullStyle))
           """
       } else if globalOptionalNulls {
-        // Global flag is true - use .type for primitives, .union for complex types
+        // Global flag is true - use .type for primitives, configured union style otherwise
         let typeInfo = type.typeInformation()
         let style: String
         switch typeInfo {
         case .primitive(let primitive, _):
           // Use .type for scalar primitives, .union for arrays/dictionaries
-          style = primitive.isScalar ? ".type" : ".union"
+          style = primitive.isScalar ? ".type" : optionalNullUnion.orNullStyleAccessor
         case .schemable:
-          // Use .union for schemable types (objects)
-          style = ".union"
+          // Use union style for schemable types (objects)
+          style = optionalNullUnion.orNullStyleAccessor
         case .notSupported:
-          // Shouldn't reach here, but default to .union
-          style = ".union"
+          // Shouldn't reach here, but default to configured union style
+          style = optionalNullUnion.orNullStyleAccessor
         }
         codeBlock = """
           \(codeBlock)

--- a/Tests/JSONSchemaBuilderTests/OrNullModifierTests.swift
+++ b/Tests/JSONSchemaBuilderTests/OrNullModifierTests.swift
@@ -137,6 +137,31 @@ struct OrNullModifierTests {
     #expect(schema.schemaValue == .object(expected))
   }
 
+  @Test func unionAnyOfStyleWithObject() {
+    @JSONSchemaBuilder var schema: some JSONSchemaComponent {
+      JSONObject {
+        JSONProperty(key: "name") {
+          JSONString()
+        }
+      }
+      .orNull(style: .unionAnyOf)
+    }
+
+    let expected: [String: JSONValue] = [
+      "anyOf": [
+        [
+          "type": "object",
+          "properties": [
+            "name": ["type": "string"]
+          ],
+        ],
+        ["type": "null"],
+      ]
+    ]
+
+    #expect(schema.schemaValue == .object(expected))
+  }
+
   // MARK: - Modifier chaining tests
 
   @Test func typeStyleWithOtherModifiers() {
@@ -171,6 +196,24 @@ struct OrNullModifierTests {
       ],
       "title": "Name",
       "description": "User's name",
+    ]
+
+    #expect(schema.schemaValue == .object(expected))
+  }
+
+  @Test func unionAnyOfStyleWithOtherModifiers() {
+    @JSONSchemaBuilder var schema: some JSONSchemaComponent {
+      JSONString()
+        .orNull(style: .unionAnyOf)
+        .title("Alias")
+    }
+
+    let expected: [String: JSONValue] = [
+      "anyOf": [
+        ["type": "string"],
+        ["type": "null"],
+      ],
+      "title": "Alias",
     ]
 
     #expect(schema.schemaValue == .object(expected))

--- a/Tests/JSONSchemaMacroTests/SchemableEnumExpansionTests.swift
+++ b/Tests/JSONSchemaMacroTests/SchemableEnumExpansionTests.swift
@@ -106,6 +106,62 @@ import Testing
     )
   }
 
+  @Test func associatedValuesAnyOfComposition() {
+    assertMacroExpansion(
+      """
+      @Schemable(enumComposition: .anyOf)
+      enum ServiceResponse {
+        case success(message: String)
+        case failure(code: Int)
+      }
+      """,
+      expandedSource: """
+        enum ServiceResponse {
+          case success(message: String)
+          case failure(code: Int)
+
+          @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+          static var schema: some JSONSchemaComponent<ServiceResponse> {
+            JSONComposition.AnyOf(into: ServiceResponse.self) {
+              JSONObject {
+                JSONProperty(key: "success") {
+                  JSONObject {
+                    JSONProperty(key: "message") {
+                      JSONString()
+                    }
+                      .required()
+                  }
+                }
+                  .required()
+              }
+                .map {
+                  Self.success(message: $0)
+                }
+              JSONObject {
+                JSONProperty(key: "failure") {
+                  JSONObject {
+                    JSONProperty(key: "code") {
+                      JSONInteger()
+                    }
+                      .required()
+                  }
+                }
+                  .required()
+              }
+                .map {
+                  Self.failure(code: $0)
+                }
+            }
+          }
+        }
+
+        extension ServiceResponse: Schemable {
+        }
+        """,
+      macros: testMacros
+    )
+  }
+
   @Test func unlabeledAssociatedValues() {
     assertMacroExpansion(
       """


### PR DESCRIPTION
## Description

- Added a public `SchemaComposition` option to `@Schemable`, plus `enumComposition` and `optionalNullUnion` parameters so generated schemas can switch between `oneOf` and `anyOf`. 
- Threaded the selected composition through the macro generators, including a new `CompositionKeyword` helper and `.unionAnyOf` support in `OrNullStyle`.
- Documented the new knobs and added macro/builder tests covering `.unionAnyOf` and `.anyOf`  expansions.
  
## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes

I’m targeting DeepSeek’s API, which only accepts anyOf compositions. Today the generated schema hardcodes oneOf both for enums with associated values and for optional arrays/objects (via .orNull(style: .union)), so the schemas produced by @Schemable are rejected even though the Swift types are correct. Exposing the composition choice lets consumers keep the macro generated code while staying compatible with platforms that disallow oneOf. The defaults remain unchanged, so existing users see no differences unless they opt in.