### PR TITLE
docs: add swift-json-schema-playground to Example Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Explore these companion repositories to see `swift-json-schema` in action:
 
 - [SwiftFunctionToolsExperiment](https://github.com/ajevans99/SwiftFunctionToolsExperiment) – demonstrates creating type-safe [OpenAI API function tool calls](https://platform.openai.com/docs/guides/function-calling) using schemas built with this library.
 - [swift-mcp-toolkit](https://github.com/ajevans99/swift-mcp-toolkit) – a toolkit built on top of the official Model Context Protocol Swift SDK ([modelcontextprotocol/swift-sdk](https://github.com/modelcontextprotocol/swift-sdk)) that makes it easy to define strongly-typed tools for MCP servers and clients.
+- [swift-json-schema-playground](https://github.com/ajevans99/swift-json-schema-playground) ([live demo](https://ajevans99.github.io/swift-json-schema-playground/)) – an in-browser JSON Schema validation playground that runs `swift-json-schema` compiled to WebAssembly via SwiftWasm, with a Monaco editor UI built on Vite + React.
 
 Have a project of your own? We'd love to showcase it. Open a PR to add your repository to this list.
 


### PR DESCRIPTION
Adds [swift-json-schema-playground](https://github.com/ajevans99/swift-json-schema-playground) to the Example Projects list.

It's an in-browser JSON Schema validation playground that runs **this library** compiled to WebAssembly via SwiftWasm, with a Monaco editor UI built on Vite + React. The wasm bridges to JavaScript via JavaScriptKit, runs in a Web Worker for responsiveness, and surfaces `ValidationError.message` / `instanceLocation` / `keywordLocation` straight from this library — no rewriting on the JS side.

**Live demo:** https://ajevans99.github.io/swift-json-schema-playground/

Building the playground also surfaced a handful of API/ergonomics suggestions, captured in [`swift-json-schema-suggestions.md`](https://github.com/ajevans99/swift-json-schema-playground/blob/main/swift-json-schema-suggestions.md) over there — happy to file individual issues here for any that look interesting.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>