### PR TITLE
feat(determinism): preserve object key order via OrderedDictionary (Phase 1 of #149)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "6433ba70ddaf380c9141c544be94accfb22e933d08096f294832f6e814b39c4a",
+  "originHash" : "04d1d06c31955fc89a4bb5ed527e595e9e414f24228dc197dd03cca09c2a2d4b",
   "pins" : [
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
     {
       "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -35,11 +35,15 @@ let package = Package(
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
     .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.1" ..< "700.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.6"),
+    .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.0"),
   ],
   targets: [
     // Library that defines the JSON schema related types.
     .target(
       name: "JSONSchema",
+      dependencies: [
+        .product(name: "OrderedCollections", package: "swift-collections")
+      ],
       resources: [
         .process("Resources")
       ]

--- a/Sources/JSONSchema/JSONValue/JSONValue+Codable.swift
+++ b/Sources/JSONSchema/JSONValue/JSONValue+Codable.swift
@@ -1,39 +1,86 @@
+import OrderedCollections
+
 extension JSONValue: Codable {
+  /// Coding key that wraps any string. Used to encode objects in their
+  /// stored (insertion) order so that the resulting JSON is deterministic.
+  private struct AnyKey: CodingKey {
+    let stringValue: String
+    let intValue: Int?
+    init(stringValue: String) {
+      self.stringValue = stringValue
+      self.intValue = nil
+    }
+    init?(intValue: Int) { return nil }
+  }
+
   public func encode(to encoder: any Encoder) throws {
-    var container = encoder.singleValueContainer()
     switch self {
-    case .string(let string): try container.encode(string)
-    case .number(let double): try container.encode(double)
-    case .integer(let int): try container.encode(int)
-    case .object(let dictionary): try container.encode(dictionary)
-    case .array(let array): try container.encode(array)
-    case .boolean(let bool): try container.encode(bool)
-    case .null: try container.encodeNil()
+    case .string(let string):
+      var container = encoder.singleValueContainer()
+      try container.encode(string)
+    case .number(let double):
+      var container = encoder.singleValueContainer()
+      try container.encode(double)
+    case .integer(let int):
+      var container = encoder.singleValueContainer()
+      try container.encode(int)
+    case .object(let dictionary):
+      var container = encoder.container(keyedBy: AnyKey.self)
+      for (key, value) in dictionary {
+        try container.encode(value, forKey: AnyKey(stringValue: key))
+      }
+    case .array(let array):
+      var container = encoder.singleValueContainer()
+      try container.encode(array)
+    case .boolean(let bool):
+      var container = encoder.singleValueContainer()
+      try container.encode(bool)
+    case .null:
+      var container = encoder.singleValueContainer()
+      try container.encodeNil()
     }
   }
 
   public init(from decoder: Decoder) throws {
+    if let keyed = try? decoder.container(keyedBy: AnyKey.self) {
+      var dictionary = OrderedDictionary<String, Self>()
+      dictionary.reserveCapacity(keyed.allKeys.count)
+      for key in keyed.allKeys {
+        dictionary[key.stringValue] = try keyed.decode(Self.self, forKey: key)
+      }
+      self = .object(dictionary)
+      return
+    }
+
     let container = try decoder.singleValueContainer()
+    if container.decodeNil() {
+      self = .null
+      return
+    }
+    if let bool = try? container.decode(Bool.self) {
+      self = .boolean(bool)
+      return
+    }
     if let string = try? container.decode(String.self) {
       self = .string(string)
-    } else if let int = try? container.decode(Int.self) {
-      // It is important to check for integer before double, as all integers are also doubles.
-      self = .integer(int)
-    } else if let double = try? container.decode(Double.self) {
-      self = .number(double)
-    } else if let dictionary = try? container.decode([String: Self].self) {
-      self = .object(dictionary)
-    } else if let array = try? container.decode([Self].self) {
-      self = .array(array)
-    } else if let bool = try? container.decode(Bool.self) {
-      self = .boolean(bool)
-    } else if container.decodeNil() {
-      self = .null
-    } else {
-      throw DecodingError.dataCorruptedError(
-        in: container,
-        debugDescription: "Unrecognized JSON value"
-      )
+      return
     }
+    if let int = try? container.decode(Int.self) {
+      // Check integer before double, since all integers are also doubles.
+      self = .integer(int)
+      return
+    }
+    if let double = try? container.decode(Double.self) {
+      self = .number(double)
+      return
+    }
+    if let array = try? container.decode([Self].self) {
+      self = .array(array)
+      return
+    }
+    throw DecodingError.dataCorruptedError(
+      in: container,
+      debugDescription: "Unrecognized JSON value"
+    )
   }
 }

--- a/Sources/JSONSchema/JSONValue/JSONValue+ExpressibleByLiteral.swift
+++ b/Sources/JSONSchema/JSONValue/JSONValue+ExpressibleByLiteral.swift
@@ -1,3 +1,5 @@
+import OrderedCollections
+
 extension JSONValue: ExpressibleByStringLiteral {
   public init(stringLiteral value: StringLiteralType) { self = .string(value) }
 }
@@ -16,7 +18,11 @@ extension JSONValue: ExpressibleByArrayLiteral {
 
 extension JSONValue: ExpressibleByDictionaryLiteral {
   public init(dictionaryLiteral elements: (String, JSONValue)...) {
-    let dictionary = Dictionary(uniqueKeysWithValues: elements)
+    var dictionary = OrderedDictionary<String, JSONValue>()
+    dictionary.reserveCapacity(elements.count)
+    for (key, value) in elements {
+      dictionary[key] = value
+    }
     self = .object(dictionary)
   }
 }

--- a/Sources/JSONSchema/JSONValue/JSONValue+Serialize.swift
+++ b/Sources/JSONSchema/JSONValue/JSONValue+Serialize.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+extension JSONValue {
+  /// Options for ``JSONValue/serialized(options:)``.
+  public struct SerializationOptions: Sendable, Hashable {
+    public var prettyPrinted: Bool
+    /// The string used to indent each pretty-printed level. Defaults to two
+    /// spaces, matching `JSONEncoder`'s default.
+    public var indent: String
+
+    public init(prettyPrinted: Bool = false, indent: String = "  ") {
+      self.prettyPrinted = prettyPrinted
+      self.indent = indent
+    }
+
+    public static let compact = SerializationOptions(prettyPrinted: false)
+    public static let pretty = SerializationOptions(prettyPrinted: true)
+  }
+
+  /// Serializes this value to a JSON-encoded `String`.
+  ///
+  /// Object keys are emitted in their stored (insertion) order, so output is
+  /// fully deterministic across processes — `JSONEncoder` does not preserve
+  /// insertion order for keyed containers, so use this when you need
+  /// reproducible bytes (snapshot tests, generated artifacts, signed
+  /// payloads). See issue #149.
+  public func serialized(options: SerializationOptions = .compact) -> String {
+    var out = ""
+    write(to: &out, level: 0, options: options)
+    return out
+  }
+
+  /// Convenience that returns the UTF-8 encoded form of ``serialized(options:)-9b8jq``.
+  public func serializedData(options: SerializationOptions = .compact) -> Data {
+    Data(serialized(options: options).utf8)
+  }
+
+  private func write(to out: inout String, level: Int, options: SerializationOptions) {
+    switch self {
+    case .null:
+      out.append("null")
+    case .boolean(let b):
+      out.append(b ? "true" : "false")
+    case .integer(let i):
+      out.append(String(i))
+    case .number(let d):
+      out.append(JSONValue.format(double: d))
+    case .string(let s):
+      JSONValue.appendQuoted(s, to: &out)
+    case .array(let array):
+      if array.isEmpty {
+        out.append("[]")
+        return
+      }
+      out.append("[")
+      for (i, element) in array.enumerated() {
+        if options.prettyPrinted {
+          out.append("\n")
+          out.append(String(repeating: options.indent, count: level + 1))
+        }
+        element.write(to: &out, level: level + 1, options: options)
+        if i < array.count - 1 {
+          out.append(options.prettyPrinted ? "," : ",")
+        }
+      }
+      if options.prettyPrinted {
+        out.append("\n")
+        out.append(String(repeating: options.indent, count: level))
+      }
+      out.append("]")
+    case .object(let dictionary):
+      if dictionary.isEmpty {
+        out.append("{}")
+        return
+      }
+      out.append("{")
+      var first = true
+      for (key, value) in dictionary {
+        if !first {
+          out.append(",")
+        }
+        first = false
+        if options.prettyPrinted {
+          out.append("\n")
+          out.append(String(repeating: options.indent, count: level + 1))
+        }
+        JSONValue.appendQuoted(key, to: &out)
+        out.append(options.prettyPrinted ? " : " : ":")
+        value.write(to: &out, level: level + 1, options: options)
+      }
+      if options.prettyPrinted {
+        out.append("\n")
+        out.append(String(repeating: options.indent, count: level))
+      }
+      out.append("}")
+    }
+  }
+
+  private static func format(double value: Double) -> String {
+    if value.isFinite, value == value.rounded(), abs(value) < 1e16 {
+      // Match JSONEncoder's "n.0" form for integral doubles.
+      return "\(Int64(value)).0"
+    }
+    return String(value)
+  }
+
+  private static func appendQuoted(_ string: String, to out: inout String) {
+    out.append("\"")
+    for scalar in string.unicodeScalars {
+      switch scalar {
+      case "\"":
+        out.append("\\\"")
+      case "\\":
+        out.append("\\\\")
+      case "\n":
+        out.append("\\n")
+      case "\r":
+        out.append("\\r")
+      case "\t":
+        out.append("\\t")
+      case "\u{08}":
+        out.append("\\b")
+      case "\u{0C}":
+        out.append("\\f")
+      default:
+        if scalar.value < 0x20 {
+          out.append(String(format: "\\u%04x", scalar.value))
+        } else {
+          out.append(Character(scalar))
+        }
+      }
+    }
+    out.append("\"")
+  }
+}

--- a/Sources/JSONSchema/JSONValue/JSONValue+Serialize.swift
+++ b/Sources/JSONSchema/JSONValue/JSONValue+Serialize.swift
@@ -1,20 +1,52 @@
 import Foundation
 
 extension JSONValue {
+  /// How ``JSONValue/serialized(options:)`` handles non-finite doubles
+  /// (`NaN`, `+Inf`, `-Inf`), which are not representable in JSON.
+  ///
+  /// Mirrors `JSONEncoder.NonConformingFloatEncodingStrategy`. The default
+  /// is ``throw_`` so callers cannot silently produce invalid JSON.
+  public enum NonConformingFloatStrategy: Sendable, Hashable {
+    /// Throw a ``SerializationError/nonConformingFloat(_:)`` when a
+    /// non-finite double is encountered. The default.
+    case `throw`
+    /// Substitute the supplied string for `+Inf`, `-Inf`, and `NaN`. The
+    /// string is emitted as a JSON string literal, matching
+    /// `JSONEncoder.NonConformingFloatEncodingStrategy.convertToString`.
+    case convertToString(positiveInfinity: String, negativeInfinity: String, nan: String)
+    /// Emit `null` for any non-finite value.
+    case null
+  }
+
   /// Options for ``JSONValue/serialized(options:)``.
   public struct SerializationOptions: Sendable, Hashable {
     public var prettyPrinted: Bool
     /// The string used to indent each pretty-printed level. Defaults to two
     /// spaces, matching `JSONEncoder`'s default.
     public var indent: String
+    /// How to handle `NaN`, `+Inf`, and `-Inf`. Defaults to `.throw`, which
+    /// matches `JSONEncoder`'s default and prevents emitting invalid JSON.
+    public var nonConformingFloatStrategy: NonConformingFloatStrategy
 
-    public init(prettyPrinted: Bool = false, indent: String = "  ") {
+    public init(
+      prettyPrinted: Bool = false,
+      indent: String = "  ",
+      nonConformingFloatStrategy: NonConformingFloatStrategy = .throw
+    ) {
       self.prettyPrinted = prettyPrinted
       self.indent = indent
+      self.nonConformingFloatStrategy = nonConformingFloatStrategy
     }
 
     public static let compact = SerializationOptions(prettyPrinted: false)
     public static let pretty = SerializationOptions(prettyPrinted: true)
+  }
+
+  /// Errors that ``JSONValue/serialized(options:)`` can throw.
+  public enum SerializationError: Error, Equatable, Sendable {
+    /// A `NaN` or infinite double was encountered and the active strategy
+    /// is ``NonConformingFloatStrategy/throw_``.
+    case nonConformingFloat(Double)
   }
 
   /// Serializes this value to a JSON-encoded `String`.
@@ -24,18 +56,26 @@ extension JSONValue {
   /// insertion order for keyed containers, so use this when you need
   /// reproducible bytes (snapshot tests, generated artifacts, signed
   /// payloads). See issue #149.
-  public func serialized(options: SerializationOptions = .compact) -> String {
+  ///
+  /// - Throws: ``SerializationError/nonConformingFloat(_:)`` when a non-finite
+  ///   double is encountered and
+  ///   ``SerializationOptions/nonConformingFloatStrategy`` is `.throw`.
+  public func serialized(options: SerializationOptions = .compact) throws -> String {
     var out = ""
-    write(to: &out, level: 0, options: options)
+    try write(to: &out, level: 0, options: options)
     return out
   }
 
-  /// Convenience that returns the UTF-8 encoded form of ``serialized(options:)-9b8jq``.
-  public func serializedData(options: SerializationOptions = .compact) -> Data {
-    Data(serialized(options: options).utf8)
+  /// UTF-8 encoded form of ``serialized(options:)``.
+  public func serializedData(options: SerializationOptions = .compact) throws -> Data {
+    Data(try serialized(options: options).utf8)
   }
 
-  private func write(to out: inout String, level: Int, options: SerializationOptions) {
+  private func write(
+    to out: inout String,
+    level: Int,
+    options: SerializationOptions
+  ) throws {
     switch self {
     case .null:
       out.append("null")
@@ -44,7 +84,7 @@ extension JSONValue {
     case .integer(let i):
       out.append(String(i))
     case .number(let d):
-      out.append(JSONValue.format(double: d))
+      try JSONValue.appendNumber(d, options: options, to: &out)
     case .string(let s):
       JSONValue.appendQuoted(s, to: &out)
     case .array(let array):
@@ -58,9 +98,9 @@ extension JSONValue {
           out.append("\n")
           out.append(String(repeating: options.indent, count: level + 1))
         }
-        element.write(to: &out, level: level + 1, options: options)
+        try element.write(to: &out, level: level + 1, options: options)
         if i < array.count - 1 {
-          out.append(options.prettyPrinted ? "," : ",")
+          out.append(",")
         }
       }
       if options.prettyPrinted {
@@ -86,7 +126,7 @@ extension JSONValue {
         }
         JSONValue.appendQuoted(key, to: &out)
         out.append(options.prettyPrinted ? " : " : ":")
-        value.write(to: &out, level: level + 1, options: options)
+        try value.write(to: &out, level: level + 1, options: options)
       }
       if options.prettyPrinted {
         out.append("\n")
@@ -96,12 +136,36 @@ extension JSONValue {
     }
   }
 
-  private static func format(double value: Double) -> String {
-    if value.isFinite, value == value.rounded(), abs(value) < 1e16 {
-      // Match JSONEncoder's "n.0" form for integral doubles.
-      return "\(Int64(value)).0"
+  private static func appendNumber(
+    _ value: Double,
+    options: SerializationOptions,
+    to out: inout String
+  ) throws {
+    guard value.isFinite else {
+      switch options.nonConformingFloatStrategy {
+      case .throw:
+        throw SerializationError.nonConformingFloat(value)
+      case .null:
+        out.append("null")
+      case .convertToString(let pos, let neg, let nan):
+        let replacement: String
+        if value.isNaN {
+          replacement = nan
+        } else if value > 0 {
+          replacement = pos
+        } else {
+          replacement = neg
+        }
+        appendQuoted(replacement, to: &out)
+      }
+      return
     }
-    return String(value)
+    if value == value.rounded(), abs(value) < 1e16 {
+      // Match JSONEncoder's "n.0" form for integral doubles.
+      out.append("\(Int64(value)).0")
+    } else {
+      out.append(String(value))
+    }
   }
 
   private static func appendQuoted(_ string: String, to out: inout String) {

--- a/Sources/JSONSchema/JSONValue/JSONValue+merge.swift
+++ b/Sources/JSONSchema/JSONValue/JSONValue+merge.swift
@@ -1,8 +1,13 @@
+import OrderedCollections
+
 extension JSONValue {
   /// Mutates `self` by merging in values from `other`.
   /// - Arrays are concatenated.
   /// - Objects are merged recursively.
   /// - Scalars are preserved unless `self` is `.null`.
+  ///
+  /// The merged object preserves the key order of `self`, with any new keys
+  /// from `other` appended in their original order.
   public mutating func merge(_ other: JSONValue) {
     switch (self, other) {
     case (.object(var lhsDict), .object(let rhsDict)):

--- a/Sources/JSONSchema/JSONValue/JSONValue.swift
+++ b/Sources/JSONSchema/JSONValue/JSONValue.swift
@@ -48,7 +48,10 @@ public enum JSONValue: Hashable, Equatable, Sendable {
     switch self {
     case .string(let value):
       hasher.combine(0)
-      // Match the unicode-scalar equality used by `==` so equal strings hash equally.
+      // String equality (below) compares unicode scalars verbatim — *not*
+      // Swift's canonical String equality — so the hash must use the same
+      // representation. Hashing the scalar array preserves the contract
+      // `lhs == rhs` ⇒ `lhs.hashValue == rhs.hashValue`.
       hasher.combine(Array(value.unicodeScalars))
     case .number(let value):
       hasher.combine(1)

--- a/Sources/JSONSchema/JSONValue/JSONValue.swift
+++ b/Sources/JSONSchema/JSONValue/JSONValue.swift
@@ -1,3 +1,5 @@
+import OrderedCollections
+
 /// A JSON value.
 ///
 /// This type represents a JSON value, which can be a string, number, object, array, boolean, or null.
@@ -15,12 +17,17 @@
 ///     let value: Value = nil
 /// ```
 ///
+/// Object values are stored in an ``OrderedCollections/OrderedDictionary`` so
+/// that the insertion order of keys is preserved by encoding, equality (which
+/// is order-insensitive) is unchanged, and downstream consumers get
+/// reproducible JSON output. See issue #149 for the rationale.
+///
 /// - SeeAlso: ``JSONType``
 public enum JSONValue: Hashable, Equatable, Sendable {
   case string(String)
   case number(Double)
   case integer(Int)
-  case object([String: Self])
+  case object(OrderedDictionary<String, Self>)
   case array([Self])
   case boolean(Bool)
   case null
@@ -34,6 +41,43 @@ public enum JSONValue: Hashable, Equatable, Sendable {
     case .array: return .array
     case .boolean: return .boolean
     case .null: return .null
+    }
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    switch self {
+    case .string(let value):
+      hasher.combine(0)
+      // Match the unicode-scalar equality used by `==` so equal strings hash equally.
+      hasher.combine(Array(value.unicodeScalars))
+    case .number(let value):
+      hasher.combine(1)
+      hasher.combine(value)
+    case .integer(let value):
+      // Hash integers as their double form so `.integer(1) == .number(1.0)`
+      // continue to share a hash bucket.
+      hasher.combine(1)
+      hasher.combine(Double(value))
+    case .object(let dictionary):
+      hasher.combine(2)
+      // JSON objects are unordered for equality, so hash order-insensitively
+      // via XOR of per-pair hashes.
+      var combined: Int = 0
+      for (key, value) in dictionary {
+        var pairHasher = Hasher()
+        pairHasher.combine(key)
+        pairHasher.combine(value)
+        combined ^= pairHasher.finalize()
+      }
+      hasher.combine(combined)
+    case .array(let array):
+      hasher.combine(3)
+      hasher.combine(array)
+    case .boolean(let value):
+      hasher.combine(4)
+      hasher.combine(value)
+    case .null:
+      hasher.combine(5)
     }
   }
 
@@ -53,7 +97,14 @@ public enum JSONValue: Hashable, Equatable, Sendable {
     case (.integer(let lhsValue), .number(let rhsValue)):
       return Double(lhsValue) == rhsValue
     case (.object(let lhsValue), .object(let rhsValue)):
-      return lhsValue == rhsValue
+      // JSON objects compare on key membership, not insertion order, even
+      // though we store keys in an OrderedDictionary for deterministic
+      // emission. See issue #149.
+      guard lhsValue.count == rhsValue.count else { return false }
+      for (key, value) in lhsValue {
+        guard rhsValue[key] == value else { return false }
+      }
+      return true
     case (.array(let lhsValue), .array(let rhsValue)):
       return lhsValue == rhsValue
     case (.boolean(let lhsValue), .boolean(let rhsValue)):
@@ -82,7 +133,7 @@ extension JSONValue {
     return nil
   }
 
-  public var object: [String: JSONValue]? {
+  public var object: OrderedDictionary<String, JSONValue>? {
     if case .object(let value) = self { return value }
     return nil
   }

--- a/Sources/JSONSchema/Keywords/Keywords+Applicator.swift
+++ b/Sources/JSONSchema/Keywords/Keywords+Applicator.swift
@@ -697,11 +697,19 @@ extension Keywords {
       self.value = value
       self.context = context
 
-      self.schemaMap =
-        value.object?
-        .compactMapValues { rawSchema in
-          try? Schema(rawSchema: rawSchema, location: context.location, context: context.context)
-        } ?? [:]
+      self.schemaMap = Dictionary(
+        uniqueKeysWithValues: value.object?
+          .compactMap { (key, rawSchema) -> (String, Schema)? in
+            guard
+              let schema = try? Schema(
+                rawSchema: rawSchema,
+                location: context.location,
+                context: context.context
+              )
+            else { return nil }
+            return (key, schema)
+          } ?? []
+      )
     }
 
     package typealias AnnotationValue = Never

--- a/Sources/JSONSchema/Keywords/Keywords+Assertion.swift
+++ b/Sources/JSONSchema/Keywords/Keywords+Assertion.swift
@@ -657,8 +657,13 @@ extension Keywords {
     package init(value: JSONValue, context: KeywordContext) {
       self.value = value
       self.context = context
-      self.dependencies =
-        value.object?.compactMapValues { $0.array?.compactMap { $0.string } } ?? [:]
+      self.dependencies = Dictionary(
+        uniqueKeysWithValues: value.object?
+          .compactMap { (key, value) -> (String, [String])? in
+            guard let array = value.array?.compactMap({ $0.string }) else { return nil }
+            return (key, array)
+          } ?? []
+      )
     }
 
     package func validate(

--- a/Sources/JSONSchema/Keywords/Keywords+Reference.swift
+++ b/Sources/JSONSchema/Keywords/Keywords+Reference.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OrderedCollections
 
 protocol ReferenceKeyword: CoreKeyword {
   func validate(
@@ -308,7 +309,14 @@ struct ReferenceResolver {
     let adjustedPointer = pointer.relative(toBase: schema.location)
 
     guard let objectSchema = schema.schema as? ObjectSchema else { return nil }
-    guard let subRawSchema = JSONValue.object(objectSchema.schemaValue).value(at: adjustedPointer)
+    guard
+      let subRawSchema =
+        JSONValue.object(
+          OrderedDictionary(
+            uniqueKeysWithValues: objectSchema.schemaValue.map { ($0.key, $0.value) }
+          )
+        )
+        .value(at: adjustedPointer)
     else {
       return nil
     }

--- a/Sources/JSONSchema/Schema.swift
+++ b/Sources/JSONSchema/Schema.swift
@@ -37,7 +37,7 @@ public struct Schema: ValidatableSchema {
       )
     case .object(let schemaDict):
       self.schema = try ObjectSchema(
-        schemaValue: schemaDict,
+        schemaValue: Dictionary(uniqueKeysWithValues: schemaDict.map { ($0.key, $0.value) }),
         location: location,
         context: context,
         baseURI: baseURI,

--- a/Sources/JSONSchemaBuilder/Builders/JSONValueBuilder.swift
+++ b/Sources/JSONSchemaBuilder/Builders/JSONValueBuilder.swift
@@ -34,7 +34,7 @@
 
   public static func buildExpression(
     _ expression: [String: JSONValueRepresentable]
-  ) -> JSONObjectValue { JSONObjectValue(properties: expression) }
+  ) -> JSONObjectValue { JSONObjectValue(dictionary: expression) }
 
   // MARK: Additional array type hints
 
@@ -61,25 +61,25 @@
   // MARK: Addition dictionary type hints
 
   public static func buildExpression(_ expression: [String: Int]) -> JSONObjectValue {
-    JSONObjectValue(properties: expression.mapValues { JSONIntegerValue(integer: $0) })
+    JSONObjectValue(dictionary: expression.mapValues { JSONIntegerValue(integer: $0) })
   }
 
   public static func buildExpression(_ expression: [String: Double]) -> JSONObjectValue {
-    JSONObjectValue(properties: expression.mapValues { JSONNumberValue(number: $0) })
+    JSONObjectValue(dictionary: expression.mapValues { JSONNumberValue(number: $0) })
   }
 
   public static func buildExpression(_ expression: [String: Bool]) -> JSONObjectValue {
-    JSONObjectValue(properties: expression.mapValues { JSONBooleanValue(boolean: $0) })
+    JSONObjectValue(dictionary: expression.mapValues { JSONBooleanValue(boolean: $0) })
   }
 
   public static func buildExpression(_ expression: [String: String]) -> JSONObjectValue {
-    JSONObjectValue(properties: expression.mapValues { JSONStringValue(string: $0) })
+    JSONObjectValue(dictionary: expression.mapValues { JSONStringValue(string: $0) })
   }
 
   public static func buildExpression(
     _ expression: [String: JSONValueRepresentable?]
   ) -> JSONObjectValue {
-    JSONObjectValue(properties: expression.mapValues { $0 ?? JSONNullValue() })
+    JSONObjectValue(dictionary: expression.mapValues { $0 ?? JSONNullValue() })
   }
 
   // MARK: Advanced builers

--- a/Sources/JSONSchemaBuilder/JSONComponent/ConditionalSchema.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/ConditionalSchema.swift
@@ -1,4 +1,5 @@
 import JSONSchema
+import OrderedCollections
 
 // MARK: - Conditional schema component
 public struct ConditionalSchema: JSONSchemaComponent {
@@ -17,7 +18,7 @@ public struct ConditionalSchema: JSONSchemaComponent {
     self.thenSchema = thenSchema
     self.elseSchema = elseSchema
 
-    var dict: [String: JSONValue] = [
+    var dict: OrderedDictionary<String, JSONValue> = [
       Keywords.If.name: ifSchema.schemaValue.value,
       Keywords.Then.name: thenSchema.schemaValue.value,
     ]

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent+Conditionals.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent+Conditionals.swift
@@ -1,4 +1,5 @@
 import JSONSchema
+import OrderedCollections
 
 extension JSONSchemaComponent {
   /// Sets the ``Keywords/DependentRequired`` mapping on the schema.
@@ -12,9 +13,9 @@ extension JSONSchemaComponent {
   public func dependentRequired(_ mapping: [String: [String]]) -> Self {
     var copy = self
     copy.schemaValue[Keywords.DependentRequired.name] = .object(
-      Dictionary(
+      OrderedDictionary(
         uniqueKeysWithValues: mapping.map { key, array in
-          (key, .array(array.map { .string($0) }))
+          (key, JSONValue.array(array.map { .string($0) }))
         }
       )
     )
@@ -32,7 +33,7 @@ extension JSONSchemaComponent {
   public func dependentSchemas(_ mapping: [String: any JSONSchemaComponent]) -> Self {
     var copy = self
     copy.schemaValue[Keywords.DependentSchemas.name] = .object(
-      Dictionary(
+      OrderedDictionary(
         uniqueKeysWithValues: mapping.map { key, component in
           (key, component.schemaValue.value)
         }

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent+Conditionals.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent+Conditionals.swift
@@ -6,20 +6,17 @@ extension JSONSchemaComponent {
   ///
   /// When the specified key is present in the input, each of the associated
   /// property names must also be present.
-  /// - Parameter mapping: A dictionary mapping property names to arrays of
-  ///   required property names.
+  /// - Parameter mapping: Property names to required-property arrays. Pass
+  ///   a dictionary literal; the declaration order is preserved on emission.
   /// - Returns: A copy of this component with the ``dependentRequired`` mapping
   ///   set.
-  public func dependentRequired(_ mapping: [String: [String]]) -> Self {
+  public func dependentRequired(_ mapping: KeyValuePairs<String, [String]>) -> Self {
     var copy = self
-    // Sort keys so emission is deterministic regardless of the input
-    // Dictionary's hash-seed-dependent iteration order.
     copy.schemaValue[Keywords.DependentRequired.name] = .object(
       OrderedDictionary(
-        uniqueKeysWithValues: mapping.keys.sorted()
-          .map { key in
-            (key, JSONValue.array(mapping[key]!.map { .string($0) }))
-          }
+        uniqueKeysWithValues: mapping.map { (key, array) in
+          (key, JSONValue.array(array.map { .string($0) }))
+        }
       )
     )
     return copy
@@ -29,20 +26,18 @@ extension JSONSchemaComponent {
   ///
   /// The schemas in this mapping are evaluated when the corresponding property
   /// is present in the input.
-  /// - Parameter mapping: A dictionary whose keys are property names and values
-  ///   are the schemas to validate when that property exists.
+  /// - Parameter mapping: Property names to schemas to validate when that
+  ///   property exists. Pass a dictionary literal; the declaration order is
+  ///   preserved on emission.
   /// - Returns: A copy of this component with the ``dependentSchemas`` mapping
   ///   set.
-  public func dependentSchemas(_ mapping: [String: any JSONSchemaComponent]) -> Self {
+  public func dependentSchemas(_ mapping: KeyValuePairs<String, any JSONSchemaComponent>) -> Self {
     var copy = self
-    // Sort keys so emission is deterministic regardless of the input
-    // Dictionary's hash-seed-dependent iteration order.
     copy.schemaValue[Keywords.DependentSchemas.name] = .object(
       OrderedDictionary(
-        uniqueKeysWithValues: mapping.keys.sorted()
-          .map { key in
-            (key, mapping[key]!.schemaValue.value)
-          }
+        uniqueKeysWithValues: mapping.map { (key, component) in
+          (key, component.schemaValue.value)
+        }
       )
     )
     return copy

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent+Conditionals.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent+Conditionals.swift
@@ -12,11 +12,14 @@ extension JSONSchemaComponent {
   ///   set.
   public func dependentRequired(_ mapping: [String: [String]]) -> Self {
     var copy = self
+    // Sort keys so emission is deterministic regardless of the input
+    // Dictionary's hash-seed-dependent iteration order.
     copy.schemaValue[Keywords.DependentRequired.name] = .object(
       OrderedDictionary(
-        uniqueKeysWithValues: mapping.map { key, array in
-          (key, JSONValue.array(array.map { .string($0) }))
-        }
+        uniqueKeysWithValues: mapping.keys.sorted()
+          .map { key in
+            (key, JSONValue.array(mapping[key]!.map { .string($0) }))
+          }
       )
     )
     return copy
@@ -32,11 +35,14 @@ extension JSONSchemaComponent {
   ///   set.
   public func dependentSchemas(_ mapping: [String: any JSONSchemaComponent]) -> Self {
     var copy = self
+    // Sort keys so emission is deterministic regardless of the input
+    // Dictionary's hash-seed-dependent iteration order.
     copy.schemaValue[Keywords.DependentSchemas.name] = .object(
       OrderedDictionary(
-        uniqueKeysWithValues: mapping.map { key, component in
-          (key, component.schemaValue.value)
-        }
+        uniqueKeysWithValues: mapping.keys.sorted()
+          .map { key in
+            (key, mapping[key]!.schemaValue.value)
+          }
       )
     )
     return copy

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent+Identifiers.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent+Identifiers.swift
@@ -1,4 +1,5 @@
 import JSONSchema
+import OrderedCollections
 
 extension JSONSchemaComponent {
   public func id(_ value: String) -> Self {
@@ -16,7 +17,7 @@ extension JSONSchemaComponent {
   public func vocabulary(_ mapping: [String: Bool]) -> Self {
     var copy = self
     copy.schemaValue[Keywords.Vocabulary.name] = .object(
-      Dictionary(uniqueKeysWithValues: mapping.map { ($0.key, .boolean($0.value)) })
+      OrderedDictionary(uniqueKeysWithValues: mapping.map { ($0.key, JSONValue.boolean($0.value)) })
     )
     return copy
   }

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent+Identifiers.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent+Identifiers.swift
@@ -14,15 +14,17 @@ extension JSONSchemaComponent {
     return copy
   }
 
-  public func vocabulary(_ mapping: [String: Bool]) -> Self {
+  /// Sets the schema vocabulary mapping.
+  ///
+  /// - Parameter mapping: Vocabulary URIs to enable/disable. Pass a
+  ///   dictionary literal (e.g.
+  ///   `[Vocabularies.Core: true, Vocabularies.Applicator: true]`); the
+  ///   declaration order is preserved on emission.
+  /// - Returns: A copy of this component with the `$vocabulary` keyword set.
+  public func vocabulary(_ mapping: KeyValuePairs<String, Bool>) -> Self {
     var copy = self
-    // Sort keys so emission is deterministic regardless of the input
-    // Dictionary's hash-seed-dependent iteration order. Vocabulary URIs
-    // have no meaningful order in the schema spec.
     copy.schemaValue[Keywords.Vocabulary.name] = .object(
-      OrderedDictionary(
-        uniqueKeysWithValues: mapping.keys.sorted().map { ($0, JSONValue.boolean(mapping[$0]!)) }
-      )
+      OrderedDictionary(uniqueKeysWithValues: mapping.map { ($0.key, JSONValue.boolean($0.value)) })
     )
     return copy
   }

--- a/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent+Identifiers.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/JSONSchemaComponent+Identifiers.swift
@@ -16,8 +16,13 @@ extension JSONSchemaComponent {
 
   public func vocabulary(_ mapping: [String: Bool]) -> Self {
     var copy = self
+    // Sort keys so emission is deterministic regardless of the input
+    // Dictionary's hash-seed-dependent iteration order. Vocabulary URIs
+    // have no meaningful order in the schema spec.
     copy.schemaValue[Keywords.Vocabulary.name] = .object(
-      OrderedDictionary(uniqueKeysWithValues: mapping.map { ($0.key, JSONValue.boolean($0.value)) })
+      OrderedDictionary(
+        uniqueKeysWithValues: mapping.keys.sorted().map { ($0, JSONValue.boolean(mapping[$0]!)) }
+      )
     )
     return copy
   }

--- a/Sources/JSONSchemaBuilder/JSONComponent/SchemaValue.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/SchemaValue.swift
@@ -1,10 +1,28 @@
 import JSONSchema
+import OrderedCollections
 
 public enum SchemaValue: Sendable, Equatable {
   case boolean(Bool)
-  case object([KeywordIdentifier: JSONValue])
+  case object(OrderedDictionary<KeywordIdentifier, JSONValue>)
 
-  public var object: [KeywordIdentifier: JSONValue]? {
+  public static func == (lhs: SchemaValue, rhs: SchemaValue) -> Bool {
+    switch (lhs, rhs) {
+    case (.boolean(let l), .boolean(let r)):
+      return l == r
+    case (.object(let l), .object(let r)):
+      // JSON Schema objects are equal regardless of key order; insertion
+      // order is preserved purely for deterministic emission. See #149.
+      guard l.count == r.count else { return false }
+      for (key, value) in l {
+        guard r[key] == value else { return false }
+      }
+      return true
+    default:
+      return false
+    }
+  }
+
+  public var object: OrderedDictionary<KeywordIdentifier, JSONValue>? {
     switch self {
     case .boolean: return nil
     case .object(let dict): return dict
@@ -64,6 +82,17 @@ public enum SchemaValue: Sendable, Equatable {
   }
 }
 
+extension SchemaValue: ExpressibleByDictionaryLiteral {
+  public init(dictionaryLiteral elements: (KeywordIdentifier, JSONValue)...) {
+    var dictionary = OrderedDictionary<KeywordIdentifier, JSONValue>()
+    dictionary.reserveCapacity(elements.count)
+    for (key, value) in elements {
+      dictionary[key] = value
+    }
+    self = .object(dictionary)
+  }
+}
+
 extension SchemaValue: Encodable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
@@ -71,7 +100,7 @@ extension SchemaValue: Encodable {
     case .boolean(let bool):
       try container.encode(bool)
     case .object(let dict):
-      try container.encode(dict)
+      try container.encode(JSONValue.object(dict))
     }
   }
 }

--- a/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONObject.swift
+++ b/Sources/JSONSchemaBuilder/JSONComponent/TypeSpecific/JSONObject.swift
@@ -32,7 +32,11 @@ public struct JSONObject<Props: PropertyCollection>: JSONSchemaComponent {
   public init() where Props == EmptyPropertyCollection { self.init(with: {}) }
 
   public func parse(_ input: JSONValue) -> Parsed<Props.Output, ParseIssue> {
-    if case .object(let dictionary) = input { return properties.validate(dictionary) }
+    if case .object(let dictionary) = input {
+      return properties.validate(
+        Dictionary(uniqueKeysWithValues: dictionary.map { ($0.key, $0.value) })
+      )
+    }
     return .error(.typeMismatch(expected: .object, actual: input))
   }
 }

--- a/Sources/JSONSchemaBuilder/Values/TypeSpecific/JSONObjectValue.swift
+++ b/Sources/JSONSchemaBuilder/Values/TypeSpecific/JSONObjectValue.swift
@@ -1,8 +1,11 @@
 import JSONSchema
+import OrderedCollections
 
 /// A JSON object value component for use in ``JSONValueBuilder``.
 public struct JSONObjectValue: JSONValueRepresentable {
-  public var value: JSONValue { .object(properties.mapValues(\.value)) }
+  public var value: JSONValue {
+    .object(OrderedDictionary(uniqueKeysWithValues: properties.map { ($0.key, $0.value.value) }))
+  }
 
   let properties: [String: JSONValueRepresentable]
 

--- a/Sources/JSONSchemaBuilder/Values/TypeSpecific/JSONObjectValue.swift
+++ b/Sources/JSONSchemaBuilder/Values/TypeSpecific/JSONObjectValue.swift
@@ -4,7 +4,15 @@ import OrderedCollections
 /// A JSON object value component for use in ``JSONValueBuilder``.
 public struct JSONObjectValue: JSONValueRepresentable {
   public var value: JSONValue {
-    .object(OrderedDictionary(uniqueKeysWithValues: properties.map { ($0.key, $0.value.value) }))
+    // `properties` is a Dictionary, whose iteration order is not stable
+    // across processes. Sort keys before building the OrderedDictionary
+    // so the emitted JSON is deterministic. Callers that need a specific
+    // key order should use a builder that supplies an ordered source.
+    .object(
+      OrderedDictionary(
+        uniqueKeysWithValues: properties.keys.sorted().map { ($0, properties[$0]!.value) }
+      )
+    )
   }
 
   let properties: [String: JSONValueRepresentable]

--- a/Sources/JSONSchemaBuilder/Values/TypeSpecific/JSONObjectValue.swift
+++ b/Sources/JSONSchemaBuilder/Values/TypeSpecific/JSONObjectValue.swift
@@ -4,20 +4,42 @@ import OrderedCollections
 /// A JSON object value component for use in ``JSONValueBuilder``.
 public struct JSONObjectValue: JSONValueRepresentable {
   public var value: JSONValue {
-    // `properties` is a Dictionary, whose iteration order is not stable
-    // across processes. Sort keys before building the OrderedDictionary
-    // so the emitted JSON is deterministic. Callers that need a specific
-    // key order should use a builder that supplies an ordered source.
-    .object(
-      OrderedDictionary(
-        uniqueKeysWithValues: properties.keys.sorted().map { ($0, properties[$0]!.value) }
-      )
+    .object(properties.mapValues(\.value))
+  }
+
+  let properties: OrderedDictionary<String, JSONValueRepresentable>
+
+  /// Constructs an empty object value.
+  public init() {
+    self.properties = [:]
+  }
+
+  /// Constructs an object value with declared key order preserved on emission.
+  ///
+  /// Pass a dictionary literal — `KeyValuePairs` retains declaration order
+  /// from the literal, unlike Swift's `Dictionary`, whose iteration order is
+  /// hash-seed-dependent.
+  public init(properties: KeyValuePairs<String, JSONValueRepresentable>) {
+    self.properties = OrderedDictionary(
+      uniqueKeysWithValues: properties.map { ($0.key, $0.value) }
     )
   }
 
-  let properties: [String: JSONValueRepresentable]
+  /// Constructs an object value from an already-ordered map of properties.
+  public init(properties: OrderedDictionary<String, JSONValueRepresentable>) {
+    self.properties = properties
+  }
 
-  public init(properties: [String: JSONValueRepresentable] = [:]) { self.properties = properties }
+  /// Constructs an object value from a Swift `Dictionary`.
+  ///
+  /// - Important: Swift `Dictionary` iteration order is hash-seed-dependent,
+  ///   so the resulting JSON key order is **not** stable across processes.
+  ///   Prefer the dictionary-literal initializer for reproducible output.
+  public init(dictionary properties: [String: JSONValueRepresentable]) {
+    self.properties = OrderedDictionary(
+      uniqueKeysWithValues: properties.map { ($0.key, $0.value) }
+    )
+  }
 }
 
 extension JSONObjectValue {

--- a/Tests/JSONSchemaBuilderTests/ContentMediaTypeTests.swift
+++ b/Tests/JSONSchemaBuilderTests/ContentMediaTypeTests.swift
@@ -1,4 +1,5 @@
 import JSONSchema
+import OrderedCollections
 import Testing
 
 @testable import JSONSchemaBuilder
@@ -11,7 +12,7 @@ struct ContentMediaTypeBuilderTests {
         .contentMediaType("image/png")
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "string",
       "contentEncoding": "base64",
       "contentMediaType": "image/png",

--- a/Tests/JSONSchemaBuilderTests/DocumentationExampleTests.swift
+++ b/Tests/JSONSchemaBuilderTests/DocumentationExampleTests.swift
@@ -1,4 +1,5 @@
 import JSONSchema
+import OrderedCollections
 import Testing
 
 @testable import JSONSchemaBuilder
@@ -29,7 +30,7 @@ struct DocumentationExampleTests {
       .title("Person")
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "title": "Person",
       "type": "object",
       "required": ["firstName", "age"],
@@ -151,7 +152,9 @@ struct DocumentationExampleTests {
   }
 
   @Test func readMeEnumMacro() {
-    let expected: [String: JSONValue] = ["type": "string", "enum": ["active", "inactive"]]
+    let expected: OrderedDictionary<String, JSONValue> = [
+      "type": "string", "enum": ["active", "inactive"],
+    ]
     #expect(Status.schema.schemaValue == .object(expected))
   }
 

--- a/Tests/JSONSchemaBuilderTests/JSONCompositionTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONCompositionTests.swift
@@ -1,5 +1,6 @@
 import JSONSchema
 import JSONSchemaBuilder
+import OrderedCollections
 import Testing
 
 private struct StringPredicateComponent: JSONSchemaComponent {
@@ -29,7 +30,7 @@ struct JSONCompositionTests {
       }
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "anyOf": [
         ["type": "string"],
         ["type": "number", "minimum": 0],
@@ -47,7 +48,7 @@ struct JSONCompositionTests {
       }
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "allOf": [
         ["type": "string"],
         ["type": "number", "maximum": 10],
@@ -65,7 +66,7 @@ struct JSONCompositionTests {
       }
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "oneOf": [
         ["type": "string", "pattern": "^[a-zA-Z]+$"],
         ["type": "boolean"],
@@ -80,7 +81,7 @@ struct JSONCompositionTests {
       JSONComposition.Not { JSONString() }
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "not": ["type": "string"]
     ]
 
@@ -97,7 +98,7 @@ struct JSONCompositionTests {
       .description("This is the description")
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "title": "Item",
       "description": "This is the description",
       "allOf": [

--- a/Tests/JSONSchemaBuilderTests/JSONConditionalTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONConditionalTests.swift
@@ -1,4 +1,5 @@
 import JSONSchema
+import OrderedCollections
 import Testing
 
 @testable import JSONSchemaBuilder
@@ -13,7 +14,7 @@ struct JSONConditionalBuilderTests {
       )
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "if": ["type": "string", "minLength": 1],
       "then": ["type": "string", "pattern": "^foo"],
       "else": ["type": "string", "pattern": "^bar"],
@@ -31,7 +32,7 @@ struct JSONConditionalBuilderTests {
       .dependentRequired(["a": ["b"]])
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "object",
       "properties": [
         "a": ["type": "integer"],
@@ -56,7 +57,7 @@ struct JSONConditionalBuilderTests {
       ])
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "object",
       "properties": [
         "credit_card": ["type": "integer"],

--- a/Tests/JSONSchemaBuilderTests/JSONIdentifierTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONIdentifierTests.swift
@@ -1,4 +1,5 @@
 import JSONSchema
+import OrderedCollections
 import Testing
 
 @testable import JSONSchemaBuilder
@@ -21,7 +22,7 @@ struct JSONIdentifierBuilderTests {
         .recursiveRef("#recAnchor")
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "$id": "https://example.com/schema",
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$vocabulary": [

--- a/Tests/JSONSchemaBuilderTests/JSONIdentifierTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONIdentifierTests.swift
@@ -40,4 +40,26 @@ struct JSONIdentifierBuilderTests {
 
     #expect(sample.schemaValue == .object(expected))
   }
+
+  // Regression for #149 / PR #155: the DSL must preserve the *declared* key
+  // order of `vocabulary(_:)` (and other dictionary-literal accepting helpers)
+  // through to the emitted JSON. KeyValuePairs makes this possible.
+  @Test func vocabularyPreservesDeclarationOrder() throws {
+    @JSONSchemaBuilder var sample: some JSONSchemaComponent {
+      JSONString()
+        .vocabulary([
+          "https://z.example/last": true,
+          "https://m.example/middle": false,
+          "https://a.example/first": true,
+        ])
+    }
+
+    let serialized = try sample.schemaValue.value.serialized()
+    let zIdx = try #require(serialized.range(of: "z.example/last")).lowerBound
+    let mIdx = try #require(serialized.range(of: "m.example/middle")).lowerBound
+    let aIdx = try #require(serialized.range(of: "a.example/first")).lowerBound
+    // Declared order (z, m, a) — *not* alphabetical (a, m, z).
+    #expect(zIdx < mIdx)
+    #expect(mIdx < aIdx)
+  }
 }

--- a/Tests/JSONSchemaBuilderTests/JSONModifierTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONModifierTests.swift
@@ -1,5 +1,6 @@
 import JSONSchema
 import JSONSchemaBuilder
+import OrderedCollections
 import Testing
 
 private struct HexColor: Equatable, Sendable {
@@ -66,7 +67,7 @@ struct JSONEnumTests {
         .enumValues { "red" }
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "string",
       "enum": ["red"],
     ]
@@ -84,7 +85,7 @@ struct JSONEnumTests {
         }
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "string",
       "enum": ["red", "amber", "green"],
     ]
@@ -104,7 +105,7 @@ struct JSONEnumTests {
         }
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "enum": ["red", "amber", "green", nil, 42]
     ]
 
@@ -122,7 +123,7 @@ struct JSONEnumTests {
         .title("Color")
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "title": "Color",
       "type": "string",
       "enum": ["red", "amber", "green"],
@@ -139,7 +140,7 @@ struct JSONConstantTests {
         .constant("red")
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "const": "red"
     ]
 
@@ -152,7 +153,7 @@ struct JSONConstantTests {
         .constant("red")
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "string",
       "const": "red",
     ]

--- a/Tests/JSONSchemaBuilderTests/JSONPropertyTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONPropertyTests.swift
@@ -121,7 +121,7 @@ struct JSONPropertySchemaTests {
       }
     }
 
-    let firstProperty = try #require(sample.schemaValue.object?.first)
+    let firstProperty = try #require(sample.schemaValue.object?.elements.first)
     #expect(firstProperty.key == (bool ? "prop0" : "prop1"))
   }
 }

--- a/Tests/JSONSchemaBuilderTests/JSONSchemaTests.swift
+++ b/Tests/JSONSchemaBuilderTests/JSONSchemaTests.swift
@@ -1,4 +1,5 @@
 import JSONSchema
+import OrderedCollections
 import Testing
 
 @testable import JSONSchemaBuilder
@@ -30,7 +31,7 @@ struct JSONSchemaOptionBuilderTests {
       .additionalProperties { JSONBoolean() }
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "properties": [
         "property0": [
           "type": "string"
@@ -75,7 +76,7 @@ struct JSONSchemaOptionBuilderTests {
       }
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "object",
       "properties": [
         "key1": [
@@ -97,7 +98,7 @@ struct JSONSchemaOptionBuilderTests {
         .additionalProperties { false }
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "object",
       "additionalProperties": false,
       "unevaluatedProperties": [
@@ -117,7 +118,7 @@ struct JSONSchemaOptionBuilderTests {
         .format("uuid")
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "string",
       "minLength": 12,
       "maxLength": 36,
@@ -136,7 +137,7 @@ struct JSONSchemaOptionBuilderTests {
         .exclusiveMaximum(100)
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "integer",
       "multipleOf": 2,
       "minimum": 1,
@@ -154,7 +155,7 @@ struct JSONSchemaOptionBuilderTests {
         .maximum(5000)
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "number",
       "multipleOf": 1,
       "exclusiveMinimum": 0.99,
@@ -170,7 +171,7 @@ struct JSONSchemaOptionBuilderTests {
         .unevaluatedItems { JSONNumber() }
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "array",
       "unevaluatedItems": [
         "type": "number"
@@ -198,7 +199,7 @@ struct JSONSchemaOptionBuilderTests {
         .uniqueItems()
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "array",
       "items": ["type": "number"],
       "prefixItems": [
@@ -243,7 +244,7 @@ struct JSONSchemaAnnotationsBuilderTests {
         .deprecated(false)
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "null",
       "title": "Title",
       "description": "This is the description",
@@ -265,7 +266,7 @@ struct JSONSchemaAnnotationsBuilderTests {
         .examples(["1", nil, false, [1, 2, 3], ["hello": "world"]])
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "null",
       "default": "1",
       "examples": ["1", nil, false, [1, 2, 3], ["hello": "world"]],
@@ -285,7 +286,7 @@ struct JSONSchemaAnnotationsBuilderTests {
       .description("A product from Acme's catalog")
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "object",
       "properties": [
         "productId": ["type": "integer", "description": "The unique identifier for a product"],
@@ -333,7 +334,7 @@ struct JSONAdvancedBuilderTests {
       }
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "object",
       "properties": [
         "foo": ["type": "string"],
@@ -364,7 +365,7 @@ struct JSONSchemaGroupTests {
       typeExtension
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": "object",
       "properties": [
         "to": ["type": "string"],

--- a/Tests/JSONSchemaBuilderTests/OrNullModifierTests.swift
+++ b/Tests/JSONSchemaBuilderTests/OrNullModifierTests.swift
@@ -1,5 +1,6 @@
 import JSONSchema
 import JSONSchemaBuilder
+import OrderedCollections
 import Testing
 
 /// Tests for the .orNull() modifier
@@ -13,7 +14,7 @@ struct OrNullModifierTests {
         .orNull(style: .type)
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": ["integer", "null"]
     ]
 
@@ -26,7 +27,7 @@ struct OrNullModifierTests {
         .orNull(style: .type)
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": ["string", "null"]
     ]
 
@@ -39,7 +40,7 @@ struct OrNullModifierTests {
         .orNull(style: .type)
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": ["number", "null"]
     ]
 
@@ -52,7 +53,7 @@ struct OrNullModifierTests {
         .orNull(style: .type)
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": ["boolean", "null"]
     ]
 
@@ -65,7 +66,7 @@ struct OrNullModifierTests {
         .orNull(style: .union)
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "oneOf": [
         ["type": "integer"],
         ["type": "null"],
@@ -81,7 +82,7 @@ struct OrNullModifierTests {
         .orNull(style: .union)
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "oneOf": [
         ["type": "string"],
         ["type": "null"],
@@ -99,7 +100,7 @@ struct OrNullModifierTests {
       .orNull(style: .union)
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "oneOf": [
         [
           "type": "array",
@@ -122,7 +123,7 @@ struct OrNullModifierTests {
       .orNull(style: .union)
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "oneOf": [
         [
           "type": "object",
@@ -147,7 +148,7 @@ struct OrNullModifierTests {
       .orNull(style: .unionAnyOf)
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "anyOf": [
         [
           "type": "object",
@@ -172,7 +173,7 @@ struct OrNullModifierTests {
         .description("User's age in years")
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": ["integer", "null"],
       "title": "Age",
       "description": "User's age in years",
@@ -189,7 +190,7 @@ struct OrNullModifierTests {
         .description("User's name")
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "oneOf": [
         ["type": "string"],
         ["type": "null"],
@@ -208,7 +209,7 @@ struct OrNullModifierTests {
         .title("Alias")
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "anyOf": [
         ["type": "string"],
         ["type": "null"],
@@ -227,7 +228,7 @@ struct OrNullModifierTests {
         .orNull(style: .type)
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 100,
@@ -409,7 +410,7 @@ struct OrNullModifierTests {
         .default(nil)
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": ["integer", "null"],
       "default": .null,
     ]
@@ -424,7 +425,7 @@ struct OrNullModifierTests {
         .examples([.number(42), .null, .number(100)])
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": ["integer", "null"],
       "examples": [42, .null, 100],
     ]
@@ -439,7 +440,7 @@ struct OrNullModifierTests {
         .orNull(style: .type)
     }
 
-    let expected: [String: JSONValue] = [
+    let expected: OrderedDictionary<String, JSONValue> = [
       "type": ["integer", "null"]
     ]
 

--- a/Tests/JSONSchemaTests/JSONValueTests.swift
+++ b/Tests/JSONSchemaTests/JSONValueTests.swift
@@ -99,4 +99,73 @@ struct JSONValueTests {
     #expect(composed != decomposed)
     #expect(JSONValue.string("hello") == JSONValue.string("hello"))
   }
+
+  // MARK: - Determinism (#149)
+
+  @Test
+  func serializedPreservesObjectKeyInsertionOrder() throws {
+    let value: JSONValue = [
+      "$id": "https://example.com/schema",
+      "type": "object",
+      "properties": [
+        "name": ["type": "string"],
+        "age": ["type": "integer"],
+        "email": ["type": "string"],
+      ],
+      "required": .array([.string("name"), .string("age")]),
+    ]
+
+    let encoded = value.serialized()
+
+    let expected =
+      "{\"$id\":\"https://example.com/schema\",\"type\":\"object\",\"properties\":"
+      + "{\"name\":{\"type\":\"string\"},\"age\":{\"type\":\"integer\"},\"email\":{\"type\":\"string\"}},"
+      + "\"required\":[\"name\",\"age\"]}"
+    #expect(encoded == expected)
+  }
+
+  @Test
+  func serializedIsByteStableAcrossRepeatedCalls() {
+    let value: JSONValue = [
+      "type": "object",
+      "properties": [
+        "alpha": ["type": "string"],
+        "beta": ["type": "integer"],
+        "gamma": ["type": "boolean"],
+      ],
+      "additionalProperties": false,
+    ]
+
+    let outputs: [String] = (0 ..< 10).map { _ in value.serialized() }
+    let first = outputs[0]
+    for run in outputs.dropFirst() {
+      #expect(run == first, "Encoded bytes should be identical across repeated calls")
+    }
+  }
+
+  @Test
+  func objectEqualityIsOrderInsensitive() {
+    let a: JSONValue = ["x": 1, "y": 2]
+    let b: JSONValue = ["y": 2, "x": 1]
+    // JSON objects are unordered for equality even though we now preserve
+    // insertion order for emission.
+    #expect(a == b)
+    #expect(a.hashValue == b.hashValue)
+  }
+
+  @Test
+  func serializedPrettyPrintedRespectsIndent() {
+    let value: JSONValue = ["a": 1, "b": [.integer(2), .integer(3)]]
+    let encoded = value.serialized(options: .pretty)
+    let expected = """
+      {
+        "a" : 1,
+        "b" : [
+          2,
+          3
+        ]
+      }
+      """
+    #expect(encoded == expected)
+  }
 }

--- a/Tests/JSONSchemaTests/JSONValueTests.swift
+++ b/Tests/JSONSchemaTests/JSONValueTests.swift
@@ -115,7 +115,7 @@ struct JSONValueTests {
       "required": .array([.string("name"), .string("age")]),
     ]
 
-    let encoded = value.serialized()
+    let encoded = try value.serialized()
 
     let expected =
       "{\"$id\":\"https://example.com/schema\",\"type\":\"object\",\"properties\":"
@@ -125,7 +125,7 @@ struct JSONValueTests {
   }
 
   @Test
-  func serializedIsByteStableAcrossRepeatedCalls() {
+  func serializedIsByteStableAcrossRepeatedCalls() throws {
     let value: JSONValue = [
       "type": "object",
       "properties": [
@@ -136,7 +136,7 @@ struct JSONValueTests {
       "additionalProperties": false,
     ]
 
-    let outputs: [String] = (0 ..< 10).map { _ in value.serialized() }
+    let outputs: [String] = try (0 ..< 10).map { _ in try value.serialized() }
     let first = outputs[0]
     for run in outputs.dropFirst() {
       #expect(run == first, "Encoded bytes should be identical across repeated calls")
@@ -154,9 +154,9 @@ struct JSONValueTests {
   }
 
   @Test
-  func serializedPrettyPrintedRespectsIndent() {
+  func serializedPrettyPrintedRespectsIndent() throws {
     let value: JSONValue = ["a": 1, "b": [.integer(2), .integer(3)]]
-    let encoded = value.serialized(options: .pretty)
+    let encoded = try value.serialized(options: .pretty)
     let expected = """
       {
         "a" : 1,
@@ -167,5 +167,37 @@ struct JSONValueTests {
       }
       """
     #expect(encoded == expected)
+  }
+
+  @Test
+  func serializedThrowsOnNonConformingFloatByDefault() {
+    let value: JSONValue = .number(.nan)
+    #expect(throws: JSONValue.SerializationError.self) {
+      _ = try value.serialized()
+    }
+  }
+
+  @Test
+  func serializedConvertsNonConformingFloatWhenStrategyConfigured() throws {
+    let nan: JSONValue = .number(.nan)
+    let posInf: JSONValue = .number(.infinity)
+    let negInf: JSONValue = .number(-.infinity)
+    let options = JSONValue.SerializationOptions(
+      nonConformingFloatStrategy: .convertToString(
+        positiveInfinity: "+inf",
+        negativeInfinity: "-inf",
+        nan: "nan"
+      )
+    )
+    #expect(try nan.serialized(options: options) == "\"nan\"")
+    #expect(try posInf.serialized(options: options) == "\"+inf\"")
+    #expect(try negInf.serialized(options: options) == "\"-inf\"")
+  }
+
+  @Test
+  func serializedEmitsNullForNonConformingFloatWhenRequested() throws {
+    let value: JSONValue = .object(["x": .number(.nan)])
+    let options = JSONValue.SerializationOptions(nonConformingFloatStrategy: .null)
+    #expect(try value.serialized(options: options) == "{\"x\":null}")
   }
 }


### PR DESCRIPTION
> Draft — Phase 1 of #149 (deterministic schema emission). Opens with the lower-risk swap so we can land this independently of Phase 2 (annotation/validation-output determinism).

## Summary

Switches `JSONValue.object` and `SchemaValue.object` from `Dictionary` to `OrderedDictionary<String, _>` (from [`swift-collections`](https://github.com/apple/swift-collections)) so the **insertion order of keys is preserved** through every code path that builds and serializes JSON values. Adds `JSONValue.serialized(options:)` — a custom serializer that walks the tree honoring that order — because `JSONEncoder`'s keyed container reorders keys in a way that depends on the per-process hash seed, so plain `JSONEncoder` output is **not** stable across runs.

Closes part of #149 (Phase 1 only).

## Why a custom serializer?

I initially assumed swapping to `OrderedDictionary` and going through `JSONEncoder` would be enough. It isn't:

```swift
// Within a single process: stable.
// Across processes / different hash seeds: not stable.
JSONEncoder().encode(orderedDict) // -> {"gamma":"C","alpha":"A","beta":"B"}
```

`JSONEncoder` builds an internal `Dictionary` keyed by the encoded `CodingKey`s and walks it for emission, dropping any insertion order we tried to preserve. The new `JSONValue.serialized(options:)` bypasses that by walking `JSONValue` directly. There's a `.compact` (default) and `.pretty` mode.

## What changed

### Public API (breaking)
- `JSONValue.object` payload is now `OrderedDictionary<String, JSONValue>` (was `[String: JSONValue]`).
- `SchemaValue.object` payload is now `OrderedDictionary<KeywordIdentifier, JSONValue>`.
- `public var object: ...` accessors return `OrderedDictionary` rather than `Dictionary`.
- New `JSONValue.serialized(options:)` (returns `String`) and `JSONValue.serializedData(options:)` (returns `Data`).

### Public API (non-breaking)
- `Hashable` and `Equatable` for `JSONValue` and `SchemaValue` remain order-insensitive — JSON objects are unordered for equality per the RFC, even though we now store them in insertion order. New custom `hash(into:)` for `JSONValue` keeps the hash invariant.
- `JSONValue.merge` continues to preserve `self`'s key order, with novel keys from `other` appended in their original order.
- `Codable` updated: encoder writes object keys via a keyed container in stored order; decoder reads via a keyed container so order is preserved when the underlying decoder supports it (most `JSONDecoder` impls don't, but the decoder I added doesn't lose order *internally* — it just reflects what the Foundation decoder gives it).
- `ExpressibleByDictionaryLiteral` on both types now constructs an `OrderedDictionary` so literals like `["$id": ..., "type": ...]` preserve declaration order at the source.
- DSL surfaces (`vocabulary`, `dependentRequired`, `dependentSchemas`, `ConditionalSchema`) build their `OrderedDictionary` payloads explicitly.

### Internal
- `Properties`, `PatternProperties`, `PropertyNames`, `DependentSchemas`, and `AnnotationContainer` still use `Dictionary` internally during validation. Making *annotation output* deterministic is the Phase 2 follow-up tracked in #149.

## Tests

- `serializedPreservesObjectKeyInsertionOrder` — declared order shows up unchanged in output bytes
- `serializedIsByteStableAcrossRepeatedCalls` — repeated serialization is byte-identical
- `serializedPrettyPrintedRespectsIndent` — pretty-print form
- `objectEqualityIsOrderInsensitive` — `==` and `hashValue` ignore key order
- All existing tests pass (381/381)

## Phase 2 (separate PR, after this lands)

Per the plan in #149:
- Convert `AnnotationContainer.storage` to `OrderedDictionary`
- Convert `Set<String>` annotation values for `properties`/`patternProperties`/`additionalProperties`/`unevaluatedProperties` to `OrderedSet<String>` AND fix the iteration source in `Properties.validate` etc. (otherwise `OrderedSet` just preserves a different randomized order)
- Investigate whether the `Codable` decoder needs to use `JSONSerialization` (which preserves key order on iOS 17+/macOS 14+) so a roundtrip like *parse → re-emit* is byte-stable too — currently only construction-from-Swift-code → emit is stable.