### PR TITLE
feat(determinism): make validation output deterministic (Phase 2 of #149)

### DIFF
--- a/Sources/JSONSchema/Annotations/AnnotationContainer.swift
+++ b/Sources/JSONSchema/Annotations/AnnotationContainer.swift
@@ -1,10 +1,15 @@
+import OrderedCollections
+
 package struct AnnotationContainer {
   struct AnnotationKey: Hashable {
     let keywordType: ObjectIdentifier
     let instanceLocation: JSONPointer
   }
 
-  private var storage: [AnnotationKey: AnyAnnotation] = [:]
+  // OrderedDictionary so `allAnnotations()` returns annotations in the
+  // order they were inserted — the validation traversal order — rather
+  // than randomized Dictionary iteration order. Required for #149.
+  private var storage: OrderedDictionary<AnnotationKey, AnyAnnotation> = [:]
 
   package init() {}
 

--- a/Sources/JSONSchema/Keywords/Keywords+Applicator.swift
+++ b/Sources/JSONSchema/Keywords/Keywords+Applicator.swift
@@ -1,3 +1,5 @@
+import OrderedCollections
+
 package protocol ApplicatorKeyword: AnnotationProducingKeyword {
   func validate(
     _ input: JSONValue,
@@ -248,7 +250,7 @@ extension Keywords {
         } ?? [:]
     }
 
-    package typealias AnnotationValue = Set<String>
+    package typealias AnnotationValue = OrderedSet<String>
 
     package func validate(
       _ input: JSONValue,
@@ -259,7 +261,7 @@ extension Keywords {
         return
       }
 
-      var instancePropertyNames: Set<String> = []
+      var instancePropertyNames: OrderedSet<String> = []
       var builder = ValidationResultBuilder(keyword: self, instanceLocation: instanceLocation)
 
       for (key, value) in instanceObject where schemaMap.keys.contains(key) {
@@ -269,7 +271,7 @@ extension Keywords {
           .validate(value, at: propertyLocation, annotations: &subAnnotations)
         builder.merging(result)
         annotations.merge(subAnnotations)
-        instancePropertyNames.insert(key)
+        instancePropertyNames.append(key)
       }
 
       try builder.throwIfErrors()
@@ -308,7 +310,7 @@ extension Keywords {
         } ?? []
     }
 
-    package typealias AnnotationValue = Set<String>
+    package typealias AnnotationValue = OrderedSet<String>
 
     package func validate(
       _ input: JSONValue,
@@ -317,7 +319,7 @@ extension Keywords {
     ) throws(ValidationIssue) {
       guard let instanceObject = input.object else { return }
 
-      var matchedPropertyNames: Set<String> = []
+      var matchedPropertyNames: OrderedSet<String> = []
       var builder = ValidationResultBuilder(keyword: self, instanceLocation: instanceLocation)
 
       for (key, value) in instanceObject {
@@ -325,7 +327,7 @@ extension Keywords {
           let propertyLocation = instanceLocation.appending(.key(key))
           let result = schema.validate(value, at: propertyLocation)
           builder.merging(result)
-          matchedPropertyNames.insert(key)
+          matchedPropertyNames.append(key)
         }
       }
 
@@ -350,7 +352,7 @@ extension Keywords {
       self.subschema = value.extractSubschema(using: context)
     }
 
-    package typealias AnnotationValue = Set<String>
+    package typealias AnnotationValue = OrderedSet<String>
 
     package func validate(
       _ input: JSONValue,
@@ -365,14 +367,14 @@ extension Keywords {
           annotations.annotation(for: PatternProperties.self, at: instanceLocation)?.value ?? []
         )
 
-      var validatedKeys: Set<String> = []
+      var validatedKeys: OrderedSet<String> = []
       var builder = ValidationResultBuilder(keyword: self, instanceLocation: instanceLocation)
 
       for (key, value) in instanceObject where !previouslyValidatedKeys.contains(key) {
         let propertyLocation = instanceLocation.appending(.key(key))
         let result = subschema.validate(value, at: propertyLocation)
         builder.merging(result)
-        validatedKeys.insert(key)
+        validatedKeys.append(key)
       }
 
       try builder.throwIfErrors()
@@ -691,13 +693,16 @@ extension Keywords {
     package let value: JSONValue
     package let context: KeywordContext
 
-    private let schemaMap: [String: Schema]
+    // OrderedDictionary so iteration in `validate(...)` happens in declared
+    // schema order — the order the user wrote properties in `dependentSchemas`
+    // — rather than randomized Dictionary order. Required for #149.
+    private let schemaMap: OrderedDictionary<String, Schema>
 
     package init(value: JSONValue, context: KeywordContext) {
       self.value = value
       self.context = context
 
-      self.schemaMap = Dictionary(
+      self.schemaMap = OrderedDictionary(
         uniqueKeysWithValues: value.object?
           .compactMap { (key, rawSchema) -> (String, Schema)? in
             guard
@@ -838,7 +843,7 @@ extension Keywords {
       self.subschema = value.extractSubschema(using: context)
     }
 
-    package typealias AnnotationValue = Set<String>
+    package typealias AnnotationValue = OrderedSet<String>
 
     package func validate(
       _ input: JSONValue,
@@ -851,7 +856,7 @@ extension Keywords {
       // See "unevaluatedProperties with nested unevaluatedProperties" from JSON schema test suite.
       guard annotations.annotation(for: Self.self, at: instanceLocation) == nil else { return }
 
-      var evaluatedPropertyNames = Set<String>()
+      var evaluatedPropertyNames = OrderedSet<String>()
 
       if let propertiesAnnotation = annotations.annotation(
         for: Properties.self,
@@ -877,9 +882,14 @@ extension Keywords {
         evaluatedPropertyNames.formUnion(additionalPropertiesAnnotation)
       }
 
-      let unevaluatedPropertyNames = Set(instanceObject.keys).subtracting(evaluatedPropertyNames)
+      // Iterate the instance object's keys in declared order (preserved by
+      // JSONValue.object's OrderedDictionary), filtering out previously
+      // evaluated names. Avoids losing order through Set.subtracting.
+      let unevaluatedPropertyNames = instanceObject.keys.filter {
+        !evaluatedPropertyNames.contains($0)
+      }
       var builder = ValidationResultBuilder(keyword: self, instanceLocation: instanceLocation)
-      var validatedPropertyNames = Set<String>()
+      var validatedPropertyNames = OrderedSet<String>()
 
       for propertyName in unevaluatedPropertyNames {
         guard let propertyValue = instanceObject[propertyName] else { continue }
@@ -892,7 +902,7 @@ extension Keywords {
         )
         builder.merging(result)
         annotations.merge(subAnnotations)
-        validatedPropertyNames.insert(propertyName)
+        validatedPropertyNames.append(propertyName)
       }
 
       try builder.throwIfErrors()
@@ -910,12 +920,12 @@ extension Never: AnnotationValueConvertible {
   package func merged(with other: Never) -> Never {}
 }
 
-extension Set: AnnotationValueConvertible where Element == String {
+extension OrderedSet: AnnotationValueConvertible where Element == String {
   package var value: JSONSchema.JSONValue {
     .array(self.map { .string($0) })
   }
 
-  package func merged(with other: Set<String>) -> Set<String> {
+  package func merged(with other: OrderedSet<String>) -> OrderedSet<String> {
     self.union(other)
   }
 }

--- a/Sources/JSONSchema/Keywords/Keywords+Applicator.swift
+++ b/Sources/JSONSchema/Keywords/Keywords+Applicator.swift
@@ -264,11 +264,15 @@ extension Keywords {
       var instancePropertyNames: OrderedSet<String> = []
       var builder = ValidationResultBuilder(keyword: self, instanceLocation: instanceLocation)
 
-      for (key, value) in instanceObject where schemaMap.keys.contains(key) {
+      for (key, value) in instanceObject {
+        guard let schema = schemaMap[key] else { continue }
         let propertyLocation = instanceLocation.appending(.key(key))
         var subAnnotations = AnnotationContainer()
-        let result = schemaMap[key]!
-          .validate(value, at: propertyLocation, annotations: &subAnnotations)
+        let result = schema.validate(
+          value,
+          at: propertyLocation,
+          annotations: &subAnnotations
+        )
         builder.merging(result)
         annotations.merge(subAnnotations)
         instancePropertyNames.append(key)
@@ -728,7 +732,10 @@ extension Keywords {
 
       var builder = ValidationResultBuilder(keyword: self, instanceLocation: instanceLocation)
 
-      for (key, schema) in schemaMap where instanceObject.keys.contains(key) {
+      // Walk schemaMap (in declared order) and consult the instance via O(1)
+      // subscript. `instanceObject.keys.contains(_:)` is also O(1) on
+      // OrderedDictionary, but `instanceObject[key] != nil` is more idiomatic.
+      for (key, schema) in schemaMap where instanceObject[key] != nil {
         var subAnnotations = AnnotationContainer()
         let result = schema.validate(input, at: instanceLocation, annotations: &subAnnotations)
         builder.merging(result)

--- a/Tests/JSONSchemaTests/KeywordTests.swift
+++ b/Tests/JSONSchemaTests/KeywordTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OrderedCollections
 import Testing
 
 @testable import JSONSchema
@@ -689,14 +690,14 @@ struct KeywordTests {
     // MARK: - Objects
 
     @Test(arguments: [
-      (JSONValue.object(["a": 1, "b": 2]), Set(["a", "b"]), true),
+      (JSONValue.object(["a": 1, "b": 2]), OrderedSet(["a", "b"]), true),
       (JSONValue.object(["a": 1, "b": "string"]), nil, false),
-      (JSONValue.object(["a": 1]), Set(["a"]), true),
-      (JSONValue.object(["b": 2]), Set(["b"]), true),
-      (JSONValue.object(["c": 3]), Set([]), true),
+      (JSONValue.object(["a": 1]), OrderedSet(["a"]), true),
+      (JSONValue.object(["b": 2]), OrderedSet(["b"]), true),
+      (JSONValue.object(["c": 3]), OrderedSet([]), true),
       (JSONValue.string("not an object"), nil, true),
     ])
-    func properties(instance: JSONValue, expectedAnnotation: Set<String>?, isValid: Bool) {
+    func properties(instance: JSONValue, expectedAnnotation: OrderedSet<String>?, isValid: Bool) {
       let schemaValue: JSONValue = [
         "a": ["type": "integer"],
         "b": ["type": "integer"],
@@ -721,14 +722,18 @@ struct KeywordTests {
     }
 
     @Test(arguments: [
-      (JSONValue.object(["a1": 1, "b2": 2]), Set(["a1", "b2"]), true),
+      (JSONValue.object(["a1": 1, "b2": 2]), OrderedSet(["a1", "b2"]), true),
       (JSONValue.object(["a1": 1, "b2": "string"]), nil, false),
-      (JSONValue.object(["a1": 1]), Set(["a1"]), true),
-      (JSONValue.object(["b2": 2]), Set(["b2"]), true),
-      (JSONValue.object(["c3": 3]), Set([]), true),
+      (JSONValue.object(["a1": 1]), OrderedSet(["a1"]), true),
+      (JSONValue.object(["b2": 2]), OrderedSet(["b2"]), true),
+      (JSONValue.object(["c3": 3]), OrderedSet([]), true),
       (JSONValue.string("not an object"), nil, true),
     ])
-    func patternProperties(instance: JSONValue, expectedAnnotation: Set<String>?, isValid: Bool) {
+    func patternProperties(
+      instance: JSONValue,
+      expectedAnnotation: OrderedSet<String>?,
+      isValid: Bool
+    ) {
       let schemaValue: JSONValue = [
         "a\\d": ["type": "integer"],
         "b\\d": ["type": "integer"],
@@ -753,14 +758,17 @@ struct KeywordTests {
     }
 
     @Test(arguments: [
-      (JSONValue.object(["a": 1, "b": 2, "c": 3]), Set(["c"]), true),
+      (JSONValue.object(["a": 1, "b": 2, "c": 3]), OrderedSet(["c"]), true),
       (JSONValue.object(["a": 1, "b": 2, "c": "string"]), nil, false),
-      (JSONValue.object(["a": 1, "b": 2]), Set([]), true),
-      (JSONValue.object(["c": 3]), Set(["c"]), true),
+      (JSONValue.object(["a": 1, "b": 2]), OrderedSet([]), true),
+      (JSONValue.object(["c": 3]), OrderedSet(["c"]), true),
       (JSONValue.string("not an object"), nil, true),
     ])
-    func additionalProperties(instance: JSONValue, expectedAnnotation: Set<String>?, isValid: Bool)
-    {
+    func additionalProperties(
+      instance: JSONValue,
+      expectedAnnotation: OrderedSet<String>?,
+      isValid: Bool
+    ) {
       let schemaValue: JSONValue = ["type": "integer"]
 
       var annotations = AnnotationContainer()

--- a/Tests/JSONSchemaTests/ValidationOutputDeterminismTests.swift
+++ b/Tests/JSONSchemaTests/ValidationOutputDeterminismTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import JSONSchema
+import OrderedCollections
+import Testing
+
+/// Phase 2 of #149 — validation output (annotations) must be deterministic.
+@Suite("Validation output determinism (#149 Phase 2)")
+struct ValidationOutputDeterminismTests {
+
+  // MARK: - Properties annotation order matches instance order
+
+  @Test
+  func propertiesAnnotationFollowsInstanceKeyOrder() throws {
+    let schemaValue: JSONValue = [
+      "properties": [
+        "alpha": ["type": "integer"],
+        "beta": ["type": "integer"],
+        "gamma": ["type": "integer"],
+      ]
+    ]
+    let schema = try Schema(rawSchema: schemaValue, context: Context(dialect: .draft2020_12))
+
+    // Instance keys in z → m → a order.
+    let instance: JSONValue = [
+      "gamma": 3,
+      "beta": 2,
+      "alpha": 1,
+    ]
+
+    let result = schema.validate(instance)
+    let propertiesAnnotation = try #require(
+      result.annotations?.first { $0.keyword == "properties" }
+    )
+    let value = try #require(propertiesAnnotation.jsonValue.array)
+    let names = value.compactMap { $0.string }
+
+    // Annotation lists matched property names in *instance* declaration order.
+    #expect(names == ["gamma", "beta", "alpha"])
+  }
+
+  // MARK: - All annotations are emitted in traversal order
+
+  @Test
+  func allAnnotationsAreEmittedInDeterministicOrder() throws {
+    let schemaValue: JSONValue = [
+      "properties": [
+        "x": ["type": "string"],
+        "y": ["type": "string"],
+      ]
+    ]
+    let schema = try Schema(rawSchema: schemaValue, context: Context(dialect: .draft2020_12))
+    let instance: JSONValue = ["y": "value", "x": "value"]
+
+    // Validate twice in the same process — collected annotation order should
+    // match exactly. (Hash-randomized Dictionary storage would have given a
+    // different ordering on each insert before Phase 2.)
+    let first = schema.validate(instance).annotations ?? []
+    let second = schema.validate(instance).annotations ?? []
+
+    let firstSig = first.map { "\($0.keyword)@\($0.instanceLocation.jsonPointerString)" }
+    let secondSig = second.map { "\($0.keyword)@\($0.instanceLocation.jsonPointerString)" }
+    #expect(firstSig == secondSig)
+  }
+
+  // MARK: - DependentSchemas iterates in declared order
+
+  @Test
+  func dependentSchemasIterateInDeclaredOrder() throws {
+    // Each dependent schema annotates a *different* sub-property's title.
+    // Putting the title at distinct instance locations avoids the merge
+    // collapse that happens when multiple annotations share a keyword +
+    // instance location. The order the title annotations appear in the
+    // result reflects the iteration order over schemaMap.
+    let schemaValue: JSONValue = [
+      "dependentSchemas": [
+        "z_trigger": ["properties": ["unique_z": ["title": "z"]]],
+        "m_trigger": ["properties": ["unique_m": ["title": "m"]]],
+        "a_trigger": ["properties": ["unique_a": ["title": "a"]]],
+      ]
+    ]
+    let schema = try Schema(rawSchema: schemaValue, context: Context(dialect: .draft2020_12))
+    let instance: JSONValue = [
+      "z_trigger": true,
+      "m_trigger": true,
+      "a_trigger": true,
+      "unique_z": 0,
+      "unique_m": 0,
+      "unique_a": 0,
+    ]
+
+    let result = schema.validate(instance)
+    let titles = (result.annotations ?? [])
+      .compactMap { ann -> String? in
+        guard ann.keyword == "title" else { return nil }
+        if case .string(let s) = ann.jsonValue { return s }
+        return nil
+      }
+
+    // Triggers walked in declared (z, m, a) order — *not* alphabetical (a, m, z).
+    #expect(titles == ["z", "m", "a"])
+  }
+
+  // MARK: - UnevaluatedProperties
+
+  @Test
+  func unevaluatedPropertiesAnnotationFollowsInstanceOrder() throws {
+    let schemaValue: JSONValue = [
+      "properties": ["known": ["type": "string"]],
+      "unevaluatedProperties": ["type": "string"],
+    ]
+    let schema = try Schema(rawSchema: schemaValue, context: Context(dialect: .draft2020_12))
+    // Instance in z → m → a order with `known` somewhere in the middle.
+    let instance: JSONValue = [
+      "z_extra": "z",
+      "known": "yes",
+      "m_extra": "m",
+      "a_extra": "a",
+    ]
+
+    let result = schema.validate(instance)
+    let unevaluated = try #require(
+      result.annotations?.first { $0.keyword == "unevaluatedProperties" }
+    )
+    guard case .array(let elements) = unevaluated.jsonValue else {
+      Issue.record("Expected unevaluatedProperties annotation to be a JSON array")
+      return
+    }
+    let names = elements.compactMap { $0.string }
+
+    // Order matches the instance, minus `known` (consumed by `properties`).
+    #expect(names == ["z_extra", "m_extra", "a_extra"])
+  }
+}

--- a/Tests/JSONSchemaTests/ValidationOutputDeterminismTests.swift
+++ b/Tests/JSONSchemaTests/ValidationOutputDeterminismTests.swift
@@ -20,7 +20,8 @@ struct ValidationOutputDeterminismTests {
     ]
     let schema = try Schema(rawSchema: schemaValue, context: Context(dialect: .draft2020_12))
 
-    // Instance keys in z → m → a order.
+    // Instance keys in gamma → beta → alpha order (intentionally not the
+    // schema's alpha → beta → gamma declared order).
     let instance: JSONValue = [
       "gamma": 3,
       "beta": 2,
@@ -42,24 +43,38 @@ struct ValidationOutputDeterminismTests {
 
   @Test
   func allAnnotationsAreEmittedInDeterministicOrder() throws {
+    // Use multiple annotation-producing keywords so the result has more than
+    // one annotation, and observe that the order matches the validation
+    // traversal: outer keywords first (title, then properties), then inner
+    // keywords (the title inside each property's subschema).
     let schemaValue: JSONValue = [
+      "title": "outer",
       "properties": [
-        "x": ["type": "string"],
-        "y": ["type": "string"],
-      ]
+        "x": ["title": "x-title", "type": "string"],
+        "y": ["title": "y-title", "type": "string"],
+      ],
     ]
     let schema = try Schema(rawSchema: schemaValue, context: Context(dialect: .draft2020_12))
     let instance: JSONValue = ["y": "value", "x": "value"]
 
-    // Validate twice in the same process — collected annotation order should
-    // match exactly. (Hash-randomized Dictionary storage would have given a
-    // different ordering on each insert before Phase 2.)
-    let first = schema.validate(instance).annotations ?? []
-    let second = schema.validate(instance).annotations ?? []
+    let result = schema.validate(instance)
+    let signatures = (result.annotations ?? [])
+      .map {
+        "\($0.keyword)@\($0.instanceLocation.jsonPointerString)"
+      }
 
-    let firstSig = first.map { "\($0.keyword)@\($0.instanceLocation.jsonPointerString)" }
-    let secondSig = second.map { "\($0.keyword)@\($0.instanceLocation.jsonPointerString)" }
-    #expect(firstSig == secondSig)
+    // properties is an applicator — its annotation is recorded *after* it
+    // processes each child schema, so the inner title annotations appear
+    // before the outer properties annotation. The y → x order on the inner
+    // titles reflects the instance's declared key order (Phase 1).
+    #expect(
+      signatures == [
+        "title@",
+        "title@/y",
+        "title@/x",
+        "properties@",
+      ]
+    )
   }
 
   // MARK: - DependentSchemas iterates in declared order


### PR DESCRIPTION
> Closes the determinism gap on the validation **output** side. Phase 1 (#155) made *emission* deterministic; this PR finishes #149 by making annotations, errors, and the order in which dependent schemas are evaluated deterministic across processes too.

## What this fixes

Before this PR, validating the same instance against the same schema produced annotation lists in a different order on every process invocation, because three things upstream of the output were randomized:

1. `AnnotationContainer.storage` was `[AnnotationKey: AnyAnnotation]` — Dictionary iteration order is hash-seed-dependent, so `allAnnotations()` returned annotations in a different order each run.
2. `Set<String>` was used for `properties` / `patternProperties` / `additionalProperties` / `unevaluatedProperties` annotation values — when serialized to a JSON array, the matched-property names came out in a random order.
3. `DependentSchemas.schemaMap` was a `Dictionary` and its `validate` iterated it directly — so dependent schemas were evaluated in random order, with knock-on effects on error and annotation ordering.

## Changes

| Site | Before | After |
|---|---|---|
| `AnnotationContainer.storage` | `[AnnotationKey: AnyAnnotation]` | `OrderedDictionary<AnnotationKey, AnyAnnotation>` |
| `Properties` / `PatternProperties` / `AdditionalProperties` / `UnevaluatedProperties` annotation type | `Set<String>` | `OrderedSet<String>` |
| `AnnotationValueConvertible` for sets of names | `Set: AnnotationValueConvertible` | `OrderedSet: AnnotationValueConvertible` |
| Validate functions building the matched-name annotation | `.insert(key)` into Set | `.append(key)` into OrderedSet (preserves traversal order) |
| `UnevaluatedProperties.validate` "what's left over" | `Set(instanceObject.keys).subtracting(evaluatedNames)` | `instanceObject.keys.filter { !evaluatedNames.contains($0) }` (preserves instance order) |
| `DependentSchemas.schemaMap` | `[String: Schema]` | `OrderedDictionary<String, Schema>` |

The new ordering of annotations and matched-name arrays is **the instance's declared key order**, which after Phase 1 is the order users actually wrote in their JSON (or the result-builder DSL).

## Behavior changes for downstream consumers

This is **breaking** at the type level for code that reads annotation values directly:

- `Annotation<Properties>.value` (and the other three) is now `OrderedSet<String>` instead of `Set<String>`. Public API for tests using `@testable import JSONSchema` was updated; downstream code reading `.value` will need the same treatment, or call `.contains(...)` (works on both).
- `AnnotationContainer.allAnnotations()` still returns `[AnyAnnotation]`. The order is now deterministic but the type is unchanged.
- `JSON output` (via `ValidationOutput` / `JSONValue.serialized`) is unchanged in shape — just stable across runs now.

## Tests

New `ValidationOutputDeterminismTests` (4 tests):

- `propertiesAnnotationFollowsInstanceKeyOrder` — instance keys in `gamma → beta → alpha` order produce a `properties` annotation in the same `gamma → beta → alpha` order.
- `allAnnotationsAreEmittedInDeterministicOrder` — running `validate(instance)` twice in the same process yields identical annotation sequences.
- `dependentSchemasIterateInDeclaredOrder` — three dependent schemas declared `z → m → a` produce title annotations in `z → m → a` order, not alphabetical.
- `unevaluatedPropertiesAnnotationFollowsInstanceOrder` — instance keys in `z → known → m → a` order produce an unevaluatedProperties annotation in `z → m → a` order (with `known` consumed by `properties`).

Existing `KeywordTests` updated to expect `OrderedSet<String>` for the four affected typealiases.

**Total test count: 394 (+4 over the post-#155 baseline).**

## Closes / part of

Closes #149.

(Combined with #155, this completes the determinism work — both schema emission and validation output are now byte-stable across processes.)
