### PR TITLE
chore: drop Swift 5.x support and Swift 6.0 compiler

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "04d1d06c31955fc89a4bb5ed527e595e9e414f24228dc197dd03cca09c2a2d4b",
+  "originHash" : "0a08a28c0c34880b80a33cfaa4b81860bb056f2d2f045890c5920dbade1a3ac7",
   "pins" : [
     {
       "identity" : "swift-collections",

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.1
 
 import CompilerPluginSupport
 import PackageDescription
@@ -162,5 +162,6 @@ let package = Package(
         "JSONSchemaConversion"
       ]
     ),
-  ]
+  ],
+  swiftLanguageModes: [.v6]
 )

--- a/Sources/JSONSchema/FormatValidators/BuiltinValidators.swift
+++ b/Sources/JSONSchema/FormatValidators/BuiltinValidators.swift
@@ -4,7 +4,7 @@ import Foundation
 
 public struct DateTimeFormatValidator: FormatValidator {
   public let formatName = "date-time"
-  private static let formatter: ISO8601DateFormatter = {
+  nonisolated(unsafe) private static let formatter: ISO8601DateFormatter = {
     let f = ISO8601DateFormatter()
     f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
     return f
@@ -32,7 +32,7 @@ public struct DateFormatValidator: FormatValidator {
 
 public struct TimeFormatValidator: FormatValidator {
   public let formatName = "time"
-  private static let regex = try! Regex(
+  nonisolated(unsafe) private static let regex = try! Regex(
     #"^(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-](?:[01]\d|2[0-3]):?[0-5]\d)?$"#
   )
 
@@ -45,13 +45,13 @@ public struct TimeFormatValidator: FormatValidator {
 
 public struct EmailFormatValidator: FormatValidator {
   public let formatName = "email"
-  private static let regex = try! Regex(#"^[^@\s]+@[^@\s]+\.[^@\s]+$"#)
+  nonisolated(unsafe) private static let regex = try! Regex(#"^[^@\s]+@[^@\s]+\.[^@\s]+$"#)
   public func validate(_ value: String) -> Bool { value.firstMatch(of: Self.regex) != nil }
 }
 
 public struct HostnameFormatValidator: FormatValidator {
   public let formatName = "hostname"
-  private static let regex = try! Regex(
+  nonisolated(unsafe) private static let regex = try! Regex(
     #"^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)(?:\.(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?))*$"#
   )
   public func validate(_ value: String) -> Bool { value.firstMatch(of: Self.regex) != nil }
@@ -59,7 +59,7 @@ public struct HostnameFormatValidator: FormatValidator {
 
 public struct IPv4FormatValidator: FormatValidator {
   public let formatName = "ipv4"
-  private static let regex = try! Regex(
+  nonisolated(unsafe) private static let regex = try! Regex(
     #"^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}$"#
   )
   public func validate(_ value: String) -> Bool { value.firstMatch(of: Self.regex) != nil }
@@ -67,7 +67,9 @@ public struct IPv4FormatValidator: FormatValidator {
 
 public struct IPv6FormatValidator: FormatValidator {
   public let formatName = "ipv6"
-  private static let regex = try! Regex(#"^(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}$"#)
+  nonisolated(unsafe) private static let regex = try! Regex(
+    #"^(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}$"#
+  )
   public func validate(_ value: String) -> Bool { value.firstMatch(of: Self.regex) != nil }
 }
 

--- a/Sources/JSONSchemaBuilder/Builders/JSONPropertySchemaBuilder.swift
+++ b/Sources/JSONSchemaBuilder/Builders/JSONPropertySchemaBuilder.swift
@@ -56,31 +56,24 @@ public struct PropertyTuple<each Property: JSONPropertyComponent>: PropertyColle
 
   public var schemaValue: SchemaValue {
     var output = SchemaValue.object([:])
-    #if swift(>=6)
-      for property in repeat each property where !property.key.isEmpty {
-
-        output[property.key] = .object(property.value.schemaValue)
-      }
-    #else
-      func schemaForProperty<Prop: JSONPropertyComponent>(_ property: Prop) {
-        guard !property.key.isEmpty else { return }
-        output[property.key] = property.value.schemaValue.value
-      }
-      repeat schemaForProperty(each property)
-    #endif
+    // The natural `for x in repeat each property { … }` form crashes
+    // SwiftPM tests at runtime under Swift 6.1.x (codegen bug, fixed in
+    // 6.3); use the helper-function pack-expansion form instead.
+    func schemaForProperty<Prop: JSONPropertyComponent>(_ property: Prop) {
+      guard !property.key.isEmpty else { return }
+      output[property.key] = property.value.schemaValue.value
+    }
+    repeat schemaForProperty(each property)
     return output
   }
 
   public var requiredKeys: [String] {
     var keys = [String]()
-    #if swift(>=6)
-      for property in repeat each property where property.isRequired { keys.append(property.key) }
-    #else
-      func addKeyIfRequired<Prop: JSONPropertyComponent>(_ property: Prop) {
-        if property.isRequired { keys.append(property.key) }
-      }
-      repeat addKeyIfRequired(each property)
-    #endif
+    // See note in `schemaValue` re: Swift 6.1.x pack-iteration codegen bug.
+    func addKeyIfRequired<Prop: JSONPropertyComponent>(_ property: Prop) {
+      if property.isRequired { keys.append(property.key) }
+    }
+    repeat addKeyIfRequired(each property)
     return keys
   }
 

--- a/Sources/JSONSchemaBuilder/Macros/Schemable.swift
+++ b/Sources/JSONSchemaBuilder/Macros/Schemable.swift
@@ -16,28 +16,24 @@ public macro Schemable(
 ) = #externalMacro(module: "JSONSchemaMacro", type: "SchemableMacro")
 
 public protocol Schemable {
-  #if compiler(>=5.9)
-    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
-    associatedtype Schema: JSONSchemaComponent
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+  associatedtype Schema: JSONSchemaComponent
 
-    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
-    @JSONSchemaBuilder static var schema: Schema { get }
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+  @JSONSchemaBuilder static var schema: Schema { get }
 
-    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
-    static var keyEncodingStrategy: KeyEncodingStrategies { get }
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+  static var keyEncodingStrategy: KeyEncodingStrategies { get }
 
-    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
-    static var defaultAnchor: String { get }
-  #endif
+  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+  static var defaultAnchor: String { get }
 }
 
-#if compiler(>=5.9)
-  @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
-  extension Schemable {
-    public static var keyEncodingStrategy: KeyEncodingStrategies { .identity }
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+extension Schemable {
+  public static var keyEncodingStrategy: KeyEncodingStrategies { .identity }
 
-    public static var defaultAnchor: String {
-      SchemaAnchorName.sanitized(String(reflecting: Self.self))
-    }
+  public static var defaultAnchor: String {
+    SchemaAnchorName.sanitized(String(reflecting: Self.self))
   }
-#endif
+}

--- a/Sources/JSONSchemaBuilder/Parsing/Parsed.swift
+++ b/Sources/JSONSchemaBuilder/Parsing/Parsed.swift
@@ -67,22 +67,16 @@ public func zip<each Value, Error>(
   } catch {
     var errors: [Error] = []
 
-    #if swift(>=6)
-      for validated in repeat each validated {
-        switch validated {
-        case .valid: continue
-        case .invalid(let array): errors.append(contentsOf: array)
-        }
+    // The natural `for x in repeat each validated { … }` form crashes
+    // SwiftPM tests at runtime under Swift 6.1.x (codegen bug, fixed in
+    // 6.3); use the helper-function pack-expansion form instead.
+    func collectErrors<Val>(_ v: Parsed<Val, Error>) {
+      switch v {
+      case .valid: break
+      case .invalid(let array): errors.append(contentsOf: array)
       }
-    #else
-      func collectErrors<Val>(_ v: Parsed<Val, Error>) {
-        switch v {
-        case .valid: break
-        case .invalid(let array): errors.append(contentsOf: array)
-        }
-      }
-      repeat collectErrors(each validated)
-    #endif
+    }
+    repeat collectErrors(each validated)
 
     return .invalid(errors)
   }

--- a/Tests/JSONSchemaTests/Utils/FileLoader.swift
+++ b/Tests/JSONSchemaTests/Utils/FileLoader.swift
@@ -20,7 +20,7 @@ struct FileLoader<T: Decodable> {
       print("Failed to find JSON files")
       return []
     }
-    return fileURLs
+    return fileURLs as [URL]
   }
 
   func loadFile(named name: String) -> T? {

--- a/Tests/OrderedJSONTests/JSONTestSuiteConformance.swift
+++ b/Tests/OrderedJSONTests/JSONTestSuiteConformance.swift
@@ -55,9 +55,9 @@ struct JSONTestSuiteConformance {
     }
   }()
 
-  private static let mustAccept = allFiles.filter { $0.lastPathComponent.hasPrefix("y_") }
-  private static let mustReject = allFiles.filter { $0.lastPathComponent.hasPrefix("n_") }
-  private static let implementationDefined = allFiles.filter {
+  private static let mustAcceptFiles = allFiles.filter { $0.lastPathComponent.hasPrefix("y_") }
+  private static let mustRejectFiles = allFiles.filter { $0.lastPathComponent.hasPrefix("n_") }
+  private static let implementationDefinedFiles = allFiles.filter {
     $0.lastPathComponent.hasPrefix("i_")
   }
 
@@ -114,7 +114,7 @@ struct JSONTestSuiteConformance {
 
   // MARK: - "Must accept" cases
 
-  @Test(arguments: mustAccept)
+  @Test(arguments: Self.mustAcceptFiles)
   func mustAccept(file: URL) throws {
     let data = try Data(contentsOf: file)
     do {
@@ -128,7 +128,7 @@ struct JSONTestSuiteConformance {
 
   // MARK: - "Must reject" cases
 
-  @Test(arguments: mustReject)
+  @Test(arguments: Self.mustRejectFiles)
   func mustReject(file: URL) throws {
     let data = try Data(contentsOf: file)
     do {
@@ -143,7 +143,7 @@ struct JSONTestSuiteConformance {
 
   // MARK: - Implementation-defined cases
 
-  @Test(arguments: implementationDefined)
+  @Test(arguments: Self.implementationDefinedFiles)
   func implementationDefinedDecision(file: URL) throws {
     let data = try Data(contentsOf: file)
     let actual: Decision = (try? JSONValue.parse(data)) != nil ? .accepted : .rejected
@@ -173,7 +173,7 @@ struct JSONTestSuiteConformance {
   /// must produce byte-identical output between the two emit passes.
   /// Locks in the parser → serializer round-trip stability that motivates
   /// this whole effort (see #149).
-  @Test(arguments: mustAccept)
+  @Test(arguments: Self.mustAcceptFiles)
   func roundtripIsByteStable(file: URL) throws {
     let data = try Data(contentsOf: file)
     guard let first = try? JSONValue.parse(data) else {


### PR DESCRIPTION
## Summary

Bump `swift-tools-version` to **6.1**, drop Swift 5.x and Swift 6.0 from the supported toolchain matrix, and clean up the now-dead `#if compiler(>=5.9)` guards. 

## Why 6.1?

Investigation of the SPI [Swift 6.0 macOS SPM build failure](https://swiftpackageindex.com/builds/70C9A259-9CEC-4146-B11D-10DE83517F78) reproduces a **Swift 6.0 compiler segfault** in the type-checker:

```
swift::PatternBindingDecl::getAnchoringVarDecl(unsigned int) const + 48
swift::FragileFunctionKindRequest::evaluate(...)
swift::DeclContext::getFragileFunctionKind()
swift::ExportContext::forFunctionBody(...)
swift::TypeChecker::checkBuilderOpSupport(...)
swift::constraints::ResultBuilder::supports(...)
```

Triggered while expanding `@ObjectOptions(.additionalProperties { false })` on `@Schemable` structs (peer-macro + `@resultBuilder` + trailing-closure attribute). Reproduced under `swift:6.0.3` on Linux; **Swift 6.1 builds cleanly**. There is no source-level workaround in this package — it requires the upstream fix shipped in 6.1.

The SPI compatibility badge already advertises **`6.3 | 6.2 | 6.1`** — Swift 6.0 has never been a usable toolchain for this package. Bumping `swift-tools-version` to 6.1 removes 6.0 from SPI's build matrix entirely.

## Changes

- **`Package.swift`** — `swift-tools-version: 5.10` → `6.1`
- **`Sources/JSONSchemaBuilder/Macros/Schemable.swift`** — remove `#if compiler(>=5.9)` wrappers around the `Schemable` protocol body and its default-impl extension. Always true with a 6.1+ compiler.
- **`Sources/JSONSchemaBuilder/Builders/JSONPropertySchemaBuilder.swift`** and **`Sources/JSONSchemaBuilder/Parsing/Parsed.swift`** — collapse `#if swift(>=6) … #else … #endif` blocks down to the previously-active branch only.

## Out of scope (potential follow-ups)

- Raising deployment targets to macOS 14 / iOS 17 / watchOS 10 / tvOS 17, which would let us drop the parameter-pack `@available(...)` annotations sprinkled across `JSONSchemaBuilder`.

## Verification

- ✅ `swift build` and `swift test` on Apple Swift 6.3.1 — all 394 tests pass.
- ✅ `swift build` on `swift:6.1` Linux container — builds clean.
- ✅ Reproduced the original 6.0 crash on `swift:6.0.3` (before this change) to confirm root cause.
- ✅ `swift-format` clean.
