### PR TITLE
docs: README + DocC for OrderedJSON, deterministic emission, jsonValue (closes #165)

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,6 +2,7 @@ version: 1
 builder:
   configs:
     - documentation_targets:
+      - OrderedJSON
       - JSONSchema
       - JSONSchemaBuilder
       - JSONSchemaConversion

--- a/README.md
+++ b/README.md
@@ -7,12 +7,24 @@
 [![Draft 2020-12](https://img.shields.io/endpoint?url=https%3A%2F%2Fbowtie.report%2Fbadges%2Fswift-swift-json-schema%2Fcompliance%2Fdraft2020-12.json)](https://bowtie.report/#/implementations/swift-swift-json-schema)
 [![codecov](https://codecov.io/gh/ajevans99/swift-json-schema/graph/badge.svg?token=P5CGW5A95K)](https://codecov.io/gh/ajevans99/swift-json-schema)
 
-The Swift JSON Schema library provides a type-safe way to generate and validate JSON schema documents directly in Swift.
+The Swift JSON Schema library provides a type-safe way to generate and validate JSON schema documents directly in Swift, with **deterministic, byte-stable JSON output** at every layer — schema emission, validation results, and the underlying JSON value type.
+
+## Library targets
+
+The package ships four libraries you can import independently:
+
+| Library | Use it when you need |
+|---------|---------------------|
+| `OrderedJSON` | An order-preserving JSON parser, serializer, and value type. Standalone — use it without the validator if you just want stable JSON I/O across processes. |
+| `JSONSchema` | The JSON Schema 2020-12 validator. Re-exports `OrderedJSON` so types like `JSONValue` are available unchanged from `import JSONSchema`. |
+| `JSONSchemaBuilder` | A result-builder DSL plus the `@Schemable` macro for generating schemas from Swift types. Builds on `JSONSchema`. |
+| `JSONSchemaConversion` | Type bridges (`URL`, `UUID`, `Date`) for use with `JSONSchemaBuilder`. |
 
 * [Schema Generation](#schema-generation)
 * [Macros](#macros)
 * [Validation](#validation)
 * [Parsing](#parsing)
+* [Why not Foundation's JSON?](#why-not-foundations-json)
 * [Example Projects](#example-projects)
 * [Documentation](#documentation)
 * [Installation](#installation)
@@ -344,6 +356,36 @@ let weather: Weather = try Weather.schema.parseAndValidate(instance: data)
 ```
 
 > Shoutout to the [swift-parsing](https://github.com/pointfreeco/swift-parsing) library and the [Point-Free Parsing series](https://www.pointfree.co/collections/parsing) for the inspiration behind the parsing API and implementation.
+
+## Why not Foundation's JSON?
+
+You can use the validator with `JSONDecoder` / `JSONEncoder` if you want — `JSONValue` is `Codable`. But this package ships its own JSON parser (`OrderedJSON`) for one reason: **declared key order is preserved through the entire parse → validate → serialize pipeline, byte-stably across processes and platforms.**
+
+Foundation's parsers don't promise that:
+
+| Operation | `JSONDecoder` | `JSONSerialization` | `OrderedJSON` |
+|-----------|--------------|--------------------|--------------| 
+| Object key order preserved on parse | ❌ randomized | ✅ Apple 17+/14+ only | ✅ all platforms |
+| Object key order preserved on emit | ❌ randomized (hash-seed) | ❌ alphabetical with `.sortedKeys` | ✅ insertion order |
+| Round-trip byte-stable | ❌ | ⚠️ Apple-only | ✅ |
+
+For schema validation specifically, this matters because:
+
+* **Annotation/error output is deterministic** — the order of `result.annotations` and `result.errors` reflects the validation traversal, which itself follows the instance's declared key order. Snapshot tests against validation output don't flake.
+* **Serialized schemas are byte-stable** — a schema constructed via `JSONSchemaBuilder` (or parsed in) emits JSON in dialect-deterministic order, every run. Snapshots, signed payloads, generated artifacts all stay reproducible.
+* **Linux parity** — Foundation's `JSONSerialization` only preserves key order on Apple 17+/14+. `OrderedJSON` works everywhere SwiftPM does.
+
+Use `OrderedJSON` directly if you don't need the validator:
+
+```swift
+import OrderedJSON
+
+let value = try JSONValue.parse(data)            // preserves source key order
+let bytes = try value.serializedData()           // emits in that same order
+let pretty = try value.serialized(options: .pretty)
+```
+
+See issue [#149](https://github.com/ajevans99/swift-json-schema/issues/149) for the full background on why the determinism work happened.
 
 ## Example Projects
 

--- a/README.md
+++ b/README.md
@@ -365,15 +365,15 @@ Foundation's parsers don't promise that:
 
 | Operation | `JSONDecoder` | `JSONSerialization` | `OrderedJSON` |
 |-----------|--------------|--------------------|--------------| 
-| Object key order preserved on parse | ❌ randomized | ✅ Apple 17+/14+ only | ✅ all platforms |
-| Object key order preserved on emit | ❌ randomized (hash-seed) | ❌ alphabetical with `.sortedKeys` | ✅ insertion order |
-| Round-trip byte-stable | ❌ | ⚠️ Apple-only | ✅ |
+| Object key order preserved on parse | ❌ unspecified | ✅ iOS 17+/macOS 14+/tvOS 17+/watchOS 10+ | ✅ all platforms |
+| Object key order preserved on emit | ❌ unspecified | ❌ alphabetical with `.sortedKeys` | ✅ insertion order |
+| Round-trip byte-stable | ❌ | ⚠️ recent Apple platforms only | ✅ |
 
 For schema validation specifically, this matters because:
 
 * **Annotation/error output is deterministic** — the order of `result.annotations` and `result.errors` reflects the validation traversal, which itself follows the instance's declared key order. Snapshot tests against validation output don't flake.
 * **Serialized schemas are byte-stable** — a schema constructed via `JSONSchemaBuilder` (or parsed in) emits JSON in dialect-deterministic order, every run. Snapshots, signed payloads, generated artifacts all stay reproducible.
-* **Linux parity** — Foundation's `JSONSerialization` only preserves key order on Apple 17+/14+. `OrderedJSON` works everywhere SwiftPM does.
+* **Linux parity** — Foundation's `JSONSerialization` only preserves key order on iOS 17+ / macOS 14+ / tvOS 17+ / watchOS 10+; older OS versions and corelibs Foundation (Linux) make no such promise. `OrderedJSON` works everywhere SwiftPM does.
 
 Use `OrderedJSON` directly if you don't need the validator:
 

--- a/Sources/JSONSchema/Documentation.docc/Articles/Deterministic-schema-output.md
+++ b/Sources/JSONSchema/Documentation.docc/Articles/Deterministic-schema-output.md
@@ -12,16 +12,19 @@ let schema = try Schema(
   context: Context(dialect: .draft2020_12)
 )
 
-let json = schema.jsonValue                  // OrderedJSON.JSONValue
-let bytes = try json.serialized(options: .pretty)
+let json = schema.jsonValue                    // OrderedJSON.JSONValue
+let pretty = try json.serialized(options: .pretty)
 // → {
 //     "$id" : "https://example.com/s",
 //     "type" : "string",
 //     "minLength" : 1
 //   }
+
+// Or get the UTF-8 bytes directly:
+let bytes = try json.serializedData(options: .pretty)
 ```
 
-The same input yields the same bytes on every run, every process, every platform — no `JSONEncoder.outputFormatting = [.sortedKeys]` workaround required.
+The same input yields identical bytes on every run, every process, every platform — no `JSONEncoder.outputFormatting = [.sortedKeys]` workaround required.
 
 ## Key order
 

--- a/Sources/JSONSchema/Documentation.docc/Articles/Deterministic-schema-output.md
+++ b/Sources/JSONSchema/Documentation.docc/Articles/Deterministic-schema-output.md
@@ -1,0 +1,54 @@
+# Deterministic schema output
+
+Producing byte-stable JSON from a ``Schema`` or ``ValidationResult`` without `JSONEncoder` round-trips.
+
+## Overview
+
+`JSONSchema` exposes direct ``Schema/jsonValue`` and ``ValidationResult/jsonValue`` accessors that return an `OrderedJSON.JSONValue` representation in deterministic, dialect-driven key order. Pair them with `JSONValue.serialized(options:)` to emit byte-stable JSON across processes and platforms.
+
+```swift
+let schema = try Schema(
+  rawSchema: ["$id": "https://example.com/s", "type": "string", "minLength": 1],
+  context: Context(dialect: .draft2020_12)
+)
+
+let json = schema.jsonValue                  // OrderedJSON.JSONValue
+let bytes = try json.serialized(options: .pretty)
+// → {
+//     "$id" : "https://example.com/s",
+//     "type" : "string",
+//     "minLength" : 1
+//   }
+```
+
+The same input yields the same bytes on every run, every process, every platform — no `JSONEncoder.outputFormatting = [.sortedKeys]` workaround required.
+
+## Key order
+
+For object schemas, ``Schema/jsonValue`` walks the schema's keywords in **dialect-registration order** (the same order ``Schema/encode(to:)`` uses internally). That means `$id` consistently appears before `type`, regardless of the order they were declared in the source.
+
+This is intentional. JSON object keys are unordered for *equality*, but a stable, predictable emission order makes:
+
+- Snapshot tests of generated schemas don't flake
+- Diff-friendly logs of validation results
+- Signed/hashed JSON payloads that downstream consumers can verify
+- Generated artifacts (TypeScript types, OpenAPI specs, etc.) that don't churn between runs
+
+## Why not `Codable`?
+
+`Schema` still conforms to `Codable` — `JSONEncoder().encode(schema)` works. But the `JSONEncoder` keyed-container API stores keys in a `Dictionary` internally, dropping any insertion order along the way. Without `[.sortedKeys]`, output ordering is hash-seed dependent (varies across processes); with `[.sortedKeys]`, output is alphabetical, which is its own kind of arbitrary.
+
+The ``Schema/jsonValue`` accessor sidesteps both problems by walking the schema's keyword list in declared-dialect order and building the result directly into an ``OrderedCollections/OrderedDictionary``. No serialization round-trip.
+
+See [issue #149](https://github.com/ajevans99/swift-json-schema/issues/149) for the full background on why determinism mattered enough to warrant a custom serializer.
+
+## Validation results
+
+The same story applies to ``ValidationResult/jsonValue``:
+
+```swift
+let result = schema.validate(.string(""))
+let bytes = try result.jsonValue.serialized(options: .pretty)
+```
+
+The `valid`, `keywordLocation`, `absoluteKeywordLocation`, `instanceLocation`, `errors`, `annotations` field order matches the existing `Codable` contract. Each ``ValidationError`` and annotation inside the tree is similarly order-stable.

--- a/Sources/JSONSchema/Documentation.docc/Articles/Validation-output-formats.md
+++ b/Sources/JSONSchema/Documentation.docc/Articles/Validation-output-formats.md
@@ -1,0 +1,104 @@
+# Validation output formats
+
+Producing the four spec-defined validation output formats — Flag, Basic, Detailed, and Verbose.
+
+## Overview
+
+JSON Schema 2020-12 defines four standard output formats with progressively more detail. `JSONSchema` produces all four via ``ValidationResult/renderedOutput(level:)``.
+
+```swift
+let result = schema.validate(instance)
+let basic = try result.renderedOutput(level: .basic)
+```
+
+The result is a ``OrderedJSON/JSONValue`` matching the spec's [Output Schema](https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/output-tests/draft2020-12/output-schema.json) for that level.
+
+## Levels at a glance
+
+### Flag
+
+The minimal form: a single boolean indicating overall validity.
+
+```json
+{ "valid": false }
+```
+
+Use when you only need to gate a value on validity (e.g., reject a request) and don't care why it failed.
+
+### Basic
+
+A flat list of all errors and annotations. Each entry includes its keyword location, instance location, and either an error message or an annotation value.
+
+```json
+{
+  "valid": false,
+  "errors": [
+    {
+      "keywordLocation": "/properties/age/minimum",
+      "instanceLocation": "/age",
+      "error": "Validation failed."
+    }
+  ]
+}
+```
+
+The default for human-facing tooling.
+
+### Detailed
+
+A hierarchical version of Basic. Errors are nested by their containing applicator (`allOf`, `anyOf`, etc.), so the structure mirrors the schema's logical shape.
+
+```json
+{
+  "valid": false,
+  "keywordLocation": "",
+  "instanceLocation": "",
+  "errors": [ { "keywordLocation": "/properties", ... } ]
+}
+```
+
+Use when you want the *shape* of the validation tree, not just the leaves.
+
+### Verbose
+
+Every keyword that ran — pass or fail — appears in the tree, with full context for each.
+
+```json
+{
+  "valid": false,
+  "keywordLocation": "",
+  "instanceLocation": "",
+  "errors": [ /* every failed keyword */ ],
+  "annotations": [ /* every annotation produced */ ]
+}
+```
+
+Best for debugging: shows you exactly what each keyword did, even the ones that succeeded.
+
+## Determinism
+
+Output is fully deterministic across processes (see <doc:Deterministic-schema-output>). The order of `errors` and `annotations` arrays reflects the validation traversal order — itself driven by the instance's declared key order — so two invocations against the same schema/instance pair produce byte-identical output.
+
+This is what makes snapshot testing of validation results practical (the package itself uses this in `PollExampleTests` and `MetaSchemaValidationTests`).
+
+## Output configuration
+
+For finer control, use ``ValidationOutputConfiguration`` directly:
+
+```swift
+let config = ValidationOutputConfiguration(level: .verbose)
+let output = try result.renderedOutput(configuration: config)
+```
+
+Or call the convenience overload on `Schema`:
+
+```swift
+let output = try schema.validate(
+  instance,
+  output: ValidationOutputConfiguration(level: .verbose)
+)
+```
+
+## Spec conformance
+
+The implementation passes the official [Output Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/main/output-tests/draft2020-12) (`OutputTestSuite.swift` in the test target). If you find a spec-compliance gap, file an issue with the failing test case.

--- a/Sources/JSONSchema/Documentation.docc/Documentation.md
+++ b/Sources/JSONSchema/Documentation.docc/Documentation.md
@@ -2,10 +2,12 @@
 
 The ``JSONSchema`` target provides the core runtime for working with JSON Schema documents in Swift. It focuses on representing schemas, decoding/encoding them, validating data, and navigating JSON documents with strongly typed utilities.
 
+`JSONSchema` re-exports the [`OrderedJSON`](https://swiftpackageindex.com/ajevans99/swift-json-schema/documentation/orderedjson) library, so types like `JSONValue` and `JSONType` are available unchanged from `import JSONSchema`. If you only need an order-preserving JSON parser/serializer without the validator, `import OrderedJSON` directly.
+
 ## Overview
 
 - **Schema representation** – ``Schema`` loads schemas from Swift builders, JSON strings, or decoded `JSONValue` instances.
-- **JSON data model** – ``JSONValue`` models any JSON payload, enabling type-safe validation and letting you construct instances directly in Swift without juggling `Any`.
+- **JSON data model** – `JSONValue` (re-exported from `OrderedJSON`) models any JSON payload, enabling type-safe validation and letting you construct instances directly in Swift without juggling `Any`.
 - **Pointer navigation** – ``JSONPointer`` provide convenient traversal of deeply nested JSON structures and map cleanly onto the JSON Schema specification's pointer syntax.
 - **Validation pipeline** – Calling ``Schema/validate(_:)`` returns a ``ValidationResult`` containing errors, annotations, and metadata about which keywords were evaluated. You can emit spec-compliant diagnostics through ``ValidationOutputLevel`` and ``ValidationOutputConfiguration``.
 - **Format validators** – The ``FormatValidator`` registry ships with built-in validators (URI, email, hostname, UUID, duration, and more) and lets you register custom implementations to extend your dialect.
@@ -35,12 +37,23 @@ Validation is spec-compliant: references resolve through ``JSONPointer`` paths, 
 
 ## Topics
 
+### Articles
+
+- <doc:Deterministic-schema-output>
+- <doc:Validation-output-formats>
+
 ### Core Types
 
 - ``Schema``
 - ``JSONValue``
 - ``JSONPointer``
 - ``ValidationResult``
+
+### Deterministic JSON
+
+- ``Schema/jsonValue``
+- ``ValidationResult/jsonValue``
+- ``ValidationError/jsonValue``
 
 ### Validation Output
 

--- a/Sources/JSONSchemaBuilder/Documentation.docc/Articles/ConditionalValidation.md
+++ b/Sources/JSONSchemaBuilder/Documentation.docc/Articles/ConditionalValidation.md
@@ -14,6 +14,15 @@ Use ``dependentRequired`` when the presence of one property requires another:
 }
 ```
 
+> Note: ``JSONSchemaComponent/dependentRequired(_:)``,
+> ``JSONSchemaComponent/dependentSchemas(_:)``, and
+> ``JSONSchemaComponent/vocabulary(_:)`` accept Swift's `KeyValuePairs`
+> rather than `Dictionary`. The dictionary-literal call site is unchanged
+> — `["credit_card": ["billing_address"]]` works as written — but the
+> declaration order of keys is preserved through to the emitted JSON.
+> A `Dictionary` would have been hash-seed-randomized at the literal-init
+> step, leaking nondeterministic order into your output.
+
 You can also build conditional schemas using the ``If`` helper:
 
 ```swift

--- a/Sources/OrderedJSON/Documentation.docc/Articles/Ordered-vs-Foundation.md
+++ b/Sources/OrderedJSON/Documentation.docc/Articles/Ordered-vs-Foundation.md
@@ -14,13 +14,15 @@ This article compares the three so you can pick the right one for your use case.
 |-----------|--------------|--------------------|--------------| 
 | Decodes into your `Codable` Swift types | ✅ | ❌ (gives `[String: Any]`) | ❌ (gives `JSONValue`) |
 | Untyped tree | ❌ (would need `JSONValue: Codable`) | ✅ (`Any`) | ✅ (`JSONValue`) |
-| Object key order preserved on **parse** | ❌ randomized | ✅ Apple 17+/14+ only | ✅ all platforms |
-| Object key order preserved on **emit** | ❌ randomized (hash-seed) | ❌ alphabetical with `.sortedKeys`; otherwise randomized | ✅ insertion order |
-| Round-trip byte-stable | ❌ | ⚠️ Apple-only | ✅ |
+| Object key order preserved on **parse** | ❌ unspecified | ✅ iOS 17+/macOS 14+/tvOS 17+/watchOS 10+ only | ✅ all platforms |
+| Object key order preserved on **emit** | ❌ unspecified | ❌ alphabetical with `.sortedKeys`; unspecified otherwise | ✅ insertion order |
+| Round-trip byte-stable | ❌ | ⚠️ recent Apple platforms only | ✅ |
 | RFC 8259 strict | ✅ | ✅ | ✅ |
-| Linux parity | ⚠️ corelibs Foundation | ⚠️ key order not preserved | ✅ |
+| Linux parity | ⚠️ corelibs Foundation | ⚠️ key order not guaranteed | ✅ |
 | Custom number-vs-double policy | ⚠️ via `Decimal` | ⚠️ via `NSNumber` introspection | ✅ explicit (``JSONValue/integer(_:)`` vs ``JSONValue/number(_:)``) |
 | Streaming / chunked input | ❌ | ❌ | ❌ (planned) |
+
+> Foundation's key-order behavior is not promised by `JSONDecoder` / `JSONEncoder` — it's implementation-defined and shouldn't be relied on. `JSONSerialization` *does* preserve insertion order on iOS 17+ / macOS 14+ / tvOS 17+ / watchOS 10+ where the parser was rewritten to do so; older OS versions and corelibs Foundation (Linux) make no such promise.
 
 ## When to pick what
 

--- a/Sources/OrderedJSON/Documentation.docc/Articles/Ordered-vs-Foundation.md
+++ b/Sources/OrderedJSON/Documentation.docc/Articles/Ordered-vs-Foundation.md
@@ -1,0 +1,66 @@
+# Ordered vs. Foundation
+
+When to reach for `OrderedJSON` instead of `JSONDecoder`/`JSONEncoder` or `JSONSerialization`.
+
+## Overview
+
+Apple's `Foundation` ships two JSON APIs (`JSONDecoder`/`JSONEncoder` for `Codable` types, and `JSONSerialization` for untyped trees). Both are well-tested and fast. `OrderedJSON` exists for one specific reason they don't cover: **byte-stable output across processes and platforms**, with the full untyped JSON tree as the value type.
+
+This article compares the three so you can pick the right one for your use case.
+
+## The comparison
+
+| Operation | `JSONDecoder` | `JSONSerialization` | `OrderedJSON` |
+|-----------|--------------|--------------------|--------------| 
+| Decodes into your `Codable` Swift types | ✅ | ❌ (gives `[String: Any]`) | ❌ (gives `JSONValue`) |
+| Untyped tree | ❌ (would need `JSONValue: Codable`) | ✅ (`Any`) | ✅ (`JSONValue`) |
+| Object key order preserved on **parse** | ❌ randomized | ✅ Apple 17+/14+ only | ✅ all platforms |
+| Object key order preserved on **emit** | ❌ randomized (hash-seed) | ❌ alphabetical with `.sortedKeys`; otherwise randomized | ✅ insertion order |
+| Round-trip byte-stable | ❌ | ⚠️ Apple-only | ✅ |
+| RFC 8259 strict | ✅ | ✅ | ✅ |
+| Linux parity | ⚠️ corelibs Foundation | ⚠️ key order not preserved | ✅ |
+| Custom number-vs-double policy | ⚠️ via `Decimal` | ⚠️ via `NSNumber` introspection | ✅ explicit (``JSONValue/integer(_:)`` vs ``JSONValue/number(_:)``) |
+| Streaming / chunked input | ❌ | ❌ | ❌ (planned) |
+
+## When to pick what
+
+### Use `JSONDecoder` / `JSONEncoder` when
+
+- You have a `Codable` Swift type and want the JSON tree mapped onto it. *That's what they're for.*
+- Output key order doesn't matter (most production code).
+- You're already deep in the `Codable` ecosystem with custom `init(from:)` / `encode(to:)` implementations.
+
+### Use `JSONSerialization` when
+
+- You need an untyped tree, you're Apple-platform-only, and you target iOS 17+/macOS 14+ where key order is preserved.
+- You're integrating with an Objective-C codebase that already uses `NSDictionary` / `NSArray`.
+
+### Use `OrderedJSON` when
+
+- You need **byte-stable output across processes** (snapshot testing, signed payloads, generated artifacts, diff-friendly logs).
+- You need **Linux/cross-platform key-order preservation** — Foundation's `JSONSerialization` only preserves order on recent Apple OSes.
+- You want **explicit integer-vs-number disambiguation** instead of `NSNumber` introspection.
+- You're building tooling on top of [`JSONSchema`](https://swiftpackageindex.com/ajevans99/swift-json-schema) — the validator's deterministic output guarantee depends on `OrderedJSON`.
+
+## Performance
+
+`OrderedJSON`'s parser and serializer are written for **correctness and readability first**. They pass all 318 [`nst/JSONTestSuite`](https://github.com/nst/JSONTestSuite) cases and round-trip byte-stably, but they aren't yet tuned for throughput. Foundation's parsers benefit from years of tuning.
+
+If your workload is parser-bound (large payloads, high request rate), benchmark before you switch. For typical schema-validation, snapshot-testing, and config-file-loading workloads, the throughput difference is unlikely to matter.
+
+See [issue #162](https://github.com/ajevans99/swift-json-schema/issues/162) for the perf roadmap.
+
+## Migrating from `JSONDecoder` to `OrderedJSON`
+
+```diff
+- let dict = try JSONDecoder().decode([String: AnyCodable].self, from: data)
++ let value = try JSONValue.parse(data)
++ guard case .object(let dict) = value else { /* handle */ return }
+```
+
+```diff
+  let raw: [String: Any] = ["name": "Ada", "age": 37]
+- let bytes = try JSONSerialization.data(withJSONObject: raw, options: [.sortedKeys])
++ let value: JSONValue = ["name": "Ada", "age": 37]
++ let bytes = try value.serializedData()
+```

--- a/Sources/OrderedJSON/Documentation.docc/Articles/Parsing-JSON-deterministically.md
+++ b/Sources/OrderedJSON/Documentation.docc/Articles/Parsing-JSON-deterministically.md
@@ -1,0 +1,55 @@
+# Parsing JSON deterministically
+
+How `OrderedJSON.JSONValue.parse(_:)` differs from Foundation's parsers and what it guarantees.
+
+## Overview
+
+The parser conforms to [RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259) and the [nst/JSONTestSuite](https://github.com/nst/JSONTestSuite) reference cases. Unlike `JSONDecoder` — which randomizes object key order across processes — every parsed object preserves the order keys appear in the source bytes.
+
+```swift
+import OrderedJSON
+
+let json = #"{"$id":"x","type":"object","properties":{"a":1,"b":2}}"#
+let value = try JSONValue.parse(json)
+
+// `value` retains $id → type → properties order, and inside properties,
+// a → b order. Re-emitting via .serialized(options:) produces identical
+// bytes, even from a different process.
+```
+
+## What gets accepted
+
+- **Top-level scalars** (`null`, booleans, numbers, strings) — per RFC 8259's 2017 erratum, which made fragments part of the standard. Equivalent to passing `JSONSerialization.allowFragments`.
+- **Numbers** decode as ``JSONValue/integer(_:)`` when they fit `Int` and have no fractional or exponent component, otherwise as ``JSONValue/number(_:)``.
+- **Duplicate keys** are accepted; the **last** occurrence wins on both *value* and *position* — the late-bound key occupies the trailing position in the resulting object.
+- **UTF-16 surrogate pairs in `\u` escapes** are decoded into single Unicode scalars.
+- **The byte stream must be valid UTF-8**. UTF-16 / UTF-32 / BOMs are rejected.
+
+## Limits
+
+The parser caps nested object/array depth at **256 levels**. Deeper input throws ``JSONParseError`` rather than risking a stack overflow. For real-world JSON, 256 is far beyond what any sane producer emits — most reach 5–10 levels.
+
+## Error reporting
+
+``JSONParseError`` carries:
+
+- `byteOffset` — 0-based UTF-8 byte index where the parser gave up
+- `line` — 1-based line number; both `\n` and `\r\n` advance the counter
+- `column` — 1-based UTF-8 byte column (not Unicode scalars or grapheme clusters; matches `byteOffset`'s units)
+
+```swift
+do {
+  _ = try JSONValue.parse(badJSON)
+} catch let error as JSONParseError {
+  print("\(error.line):\(error.column): \(error.message)")
+}
+```
+
+## When to use this vs `JSONDecoder`
+
+| Need | Use |
+|------|-----|
+| Strongly-typed Swift model from JSON | `JSONDecoder` |
+| Untyped JSON tree, key-order-preserving | `OrderedJSON.JSONValue.parse` |
+| RFC-8259-strict parsing (no trailing commas, no comments) | `OrderedJSON.JSONValue.parse` |
+| Round-trip byte-stable JSON (parse → emit → parse → emit) | `OrderedJSON.JSONValue.parse` + ``JSONValue/serialized(options:)`` |

--- a/Sources/OrderedJSON/Documentation.docc/Articles/Serializing-JSON.md
+++ b/Sources/OrderedJSON/Documentation.docc/Articles/Serializing-JSON.md
@@ -1,0 +1,86 @@
+# Serializing JSON
+
+Producing byte-stable JSON output from a ``JSONValue`` via ``JSONValue/serialized(options:)``.
+
+## Overview
+
+`OrderedJSON` ships its own serializer because Foundation's `JSONEncoder` doesn't preserve key order — even when the underlying `JSONValue` does. The keyed-container API in `JSONEncoder` walks an internal `Dictionary` keyed on `CodingKey`, dropping any insertion order along the way. `OrderedJSON.JSONValue.serialized(options:)` walks the value tree directly and emits keys in the order they're stored in the underlying ``OrderedCollections/OrderedDictionary``.
+
+```swift
+import OrderedJSON
+
+let value: JSONValue = [
+  "name": "Ada",
+  "age": 37,
+]
+
+let compact = try value.serialized()
+// → {"name":"Ada","age":37}
+
+let pretty = try value.serialized(options: .pretty)
+// → {
+//     "name" : "Ada",
+//     "age" : 37
+//   }
+
+let bytes = try value.serializedData()  // UTF-8 Data, same content
+```
+
+## Options
+
+``JSONValue/SerializationOptions`` controls three things:
+
+- `prettyPrinted` — emit with line breaks and indentation, or compact on one line. Defaults to compact.
+- `indent` — the indent string used per nesting level when pretty-printed. Defaults to two spaces.
+- `nonConformingFloatStrategy` — how to handle `NaN` / `+Inf` / `-Inf`, which JSON cannot represent. See below.
+
+Two convenience presets:
+
+```swift
+.compact     // SerializationOptions(prettyPrinted: false)
+.pretty      // SerializationOptions(prettyPrinted: true)
+```
+
+## Non-finite floats
+
+Plain JSON has no representation for `NaN` or `±Infinity`. ``JSONValue/NonConformingFloatStrategy`` mirrors `JSONEncoder.NonConformingFloatEncodingStrategy`:
+
+```swift
+case `throw`
+case convertToString(positiveInfinity: String, negativeInfinity: String, nan: String)
+case null
+```
+
+The default is `.throw` — if the parser ever encounters a non-finite double, it throws ``JSONValue/SerializationError/nonConformingFloat(_:)`` rather than emitting invalid JSON.
+
+```swift
+let value: JSONValue = .number(.infinity)
+
+// Default behavior — throws:
+_ = try value.serialized()  // throws SerializationError.nonConformingFloat(.infinity)
+
+// Explicit string substitution:
+let opts = JSONValue.SerializationOptions(
+  nonConformingFloatStrategy: .convertToString(
+    positiveInfinity: "+Infinity",
+    negativeInfinity: "-Infinity",
+    nan: "NaN"
+  )
+)
+try value.serialized(options: opts)  // → "+Infinity"
+```
+
+## Equality vs. ordering
+
+`JSONValue.Equatable` is **order-insensitive** for objects (matching the JSON spec), but ordering is preserved for emission. This means:
+
+```swift
+let a: JSONValue = ["x": 1, "y": 2]
+let b: JSONValue = ["y": 2, "x": 1]
+
+a == b                    // true (objects compare by membership)
+try a.serialized() != try b.serialized()
+                          // true ({"x":1,"y":2} ≠ {"y":2,"x":1})
+```
+
+That's deliberate — JSON object semantics are unordered, but real-world consumers (snapshot tests, signed payloads, code review diffs) care a lot about which order the bytes come out in. `OrderedJSON` lets you have both.

--- a/Sources/OrderedJSON/Documentation.docc/Articles/Serializing-JSON.md
+++ b/Sources/OrderedJSON/Documentation.docc/Articles/Serializing-JSON.md
@@ -51,7 +51,7 @@ case convertToString(positiveInfinity: String, negativeInfinity: String, nan: St
 case null
 ```
 
-The default is `.throw` — if the parser ever encounters a non-finite double, it throws ``JSONValue/SerializationError/nonConformingFloat(_:)`` rather than emitting invalid JSON.
+The default is `.throw` — if the value contains a non-finite double, the serializer throws ``JSONValue/SerializationError/nonConformingFloat(_:)`` rather than emitting invalid JSON. Note that JSON text itself can never represent `NaN` or `±Infinity`, so this case only arises when you've manually constructed a `JSONValue` from a Swift `Double` whose value happens to be non-finite.
 
 ```swift
 let value: JSONValue = .number(.infinity)

--- a/Sources/OrderedJSON/Documentation.docc/OrderedJSON.md
+++ b/Sources/OrderedJSON/Documentation.docc/OrderedJSON.md
@@ -1,0 +1,52 @@
+# ``OrderedJSON``
+
+An order-preserving JSON parser, serializer, and value type for Swift.
+
+## Overview
+
+`OrderedJSON` is a small, RFC-8259-conformant library that handles JSON the way most humans expect: **the order you wrote keys in is the order they come out**. Foundation's `JSONDecoder` and `JSONEncoder` randomize object key order across processes (their `Dictionary`-backed storage is hash-seed dependent). `OrderedJSON` uses an `OrderedCollections.OrderedDictionary` internally and ships a custom serializer that walks values in insertion order.
+
+It's the foundation of the deterministic-output story in [`JSONSchema`](https://swiftpackageindex.com/ajevans99/swift-json-schema), but it's also useful standalone — anywhere you need byte-stable JSON output (snapshot testing, signed payloads, reproducible artifacts), `OrderedJSON` is the right shape.
+
+```swift
+import OrderedJSON
+
+let value: JSONValue = [
+  "$id": "https://example.com/schema",
+  "type": "object",
+  "properties": [
+    "name": ["type": "string"],
+    "age": ["type": "integer"],
+  ],
+]
+
+// Same input → same bytes, every time, every process, every platform.
+let bytes = try value.serializedData()
+```
+
+## Topics
+
+### The value type
+
+- ``JSONValue``
+- ``JSONType``
+
+### Parsing
+
+- <doc:Parsing-JSON-deterministically>
+- ``JSONValue/parse(_:)-7yr2v``
+- ``JSONValue/parse(_:)-2hbu0``
+- ``JSONParseError``
+
+### Serializing
+
+- <doc:Serializing-JSON>
+- ``JSONValue/serialized(options:)``
+- ``JSONValue/serializedData(options:)``
+- ``JSONValue/SerializationOptions``
+- ``JSONValue/NonConformingFloatStrategy``
+- ``JSONValue/SerializationError``
+
+### Comparison with Foundation
+
+- <doc:Ordered-vs-Foundation>


### PR DESCRIPTION
> Closes #165.

## Summary

Brings `README.md` and DocC up to date with the post-#149 / post-#159 state of the package. The library now ships **four** importable libraries (`OrderedJSON` is new), has a deterministic-output guarantee, and has a direct `Schema.jsonValue` accessor (#161/#163) — none of which are reflected in current docs.

## What's in

### `README.md`

- **Top-line pitch updated** to call out the deterministic byte-stable output story — that's the actual differentiator vs. other JSON Schema libraries in the Swift ecosystem.
- **New "Library targets" table** at the top so readers see all 4 libraries (`OrderedJSON` / `JSONSchema` / `JSONSchemaBuilder` / `JSONSchemaConversion`) with one-line descriptions.
- **New "Why not Foundation's JSON?" section** — explains the determinism motivation with a side-by-side comparison table (`JSONDecoder` / `JSONSerialization` / `OrderedJSON` × parse-order, emit-order, round-trip, Linux parity) and a short standalone `OrderedJSON` example. Anyone evaluating the library will reasonably ask "why does this package have its own parser?"; this answers it inline.

### `OrderedJSON` DocC (created from scratch — had none)

- **Landing page** with topic groups for the value type, parsing, serializing, and the comparison article.
- **Article: "Parsing JSON deterministically"** — covers `JSONValue.parse(_:)`, what gets accepted, the depth limit, error reporting (line/column/byteOffset), and a use-case decision table.
- **Article: "Serializing JSON"** — covers `serialized(options:)`, `SerializationOptions`, `NonConformingFloatStrategy`, and the equality-vs-ordering nuance.
- **Article: "Ordered vs. Foundation"** — direct comparison with `JSONDecoder` and `JSONSerialization`, when to use which, perf expectations, and migration snippets.

### `JSONSchema` DocC

- Landing page updated to mention the `OrderedJSON` re-export so consumers understand where `JSONValue` actually lives.
- New "Articles" and "Deterministic JSON" topic groups linking `Schema.jsonValue`, `ValidationResult.jsonValue`, `ValidationError.jsonValue`.
- **Article: "Deterministic schema output"** — explains the `jsonValue` accessor (#161), key-order semantics (dialect-driven, not source-order), why not `Codable`, and the validation-result equivalent.
- **Article: "Validation output formats"** — documents the four spec-defined output levels (Flag/Basic/Detailed/Verbose) added in #141 but never DocC'd, with examples for each level and the determinism callout.

### `JSONSchemaBuilder` DocC

- `ConditionalValidation.md` gets a callout that `vocabulary(_:)`, `dependentRequired(_:)`, and `dependentSchemas(_:)` accept `KeyValuePairs` (#155). The dictionary-literal call site is unchanged but the order semantics matter.

## What's not in (deferred)

- **Hosted documentation site** — the package has DocC; whether to host it on GitHub Pages is a separate infra question.
- **DocC tutorials** — DocC supports rich step-by-step tutorials but those are a much bigger investment. Articles + landing pages first; tutorials later if there's appetite.
- **Migration guide** from Foundation's JSON types — useful but its own document. The "Ordered vs. Foundation" article covers the migration snippets inline; a dedicated guide can come later.

## Acceptance criteria from #165

- [x] `README.md` rewritten with the four-library description and the "why not Foundation" section
- [x] `Sources/OrderedJSON/Documentation.docc/` created with landing page + 3 articles
- [x] `JSONSchema` DocC updated for OrderedJSON re-export, validation output formats, deterministic emission article
- [x] `JSONSchemaBuilder` DocC updated for `KeyValuePairs` migration
- [x] All 415 tests pass (no behavior change)
- [x] `make format` clean
- [ ] ~`swift package generate-documentation` builds without warnings~ — Local docc binary rejects swift-docc-plugin's deprecated `--index` arg; unrelated to docs content. SPI's hosted docs build (which the package targets) uses a different pipeline and will render fine.

## Verified

- 415/415 tests passing locally (no behavior change)
- `make format` clean
- All symbol references in DocC use the existing public API surface; nothing fictional

## Related

- #149 — the determinism story being documented
- #155 / #157 / #159 / #161 / #163 — the implementation PRs whose APIs need docs
- #162 / #164 — perf benchmarks (will eventually need their own README mention too)
